### PR TITLE
[Don't merge] Note about nn/experiment

### DIFF
--- a/Sources/TryParsecExperiment/Combinator.swift
+++ b/Sources/TryParsecExperiment/Combinator.swift
@@ -1,0 +1,196 @@
+/// Parses zero or one occurrence of `parser`.
+/// - SeeAlso: Haskell Parsec's `optionMaybe`.
+public func zeroOrOne<Out>(parser: Result<Out>.Parser) -> Result<Out?>.Parser {
+    return parser <&> Optional<Out>.init // <|> pure(Optional<Out>.None)
+}
+
+/// Parses zero or more occurrences of `parser`.
+/// - Note: Returning parser never fails.
+public func many<Outs: RangeReplaceableCollectionType>(parser: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
+    return many1(parser) <|> { pure(Outs()) }
+}
+
+/// Parses one or more occurrences of `parser`.
+public func many1<Outs: RangeReplaceableCollectionType>(parser: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
+    return cons <^> parser <*> { many(parser) }
+}
+
+/// Parses one or more occurrences of `parser` until `end` succeeds,
+/// and returns the list of values returned by `parser`.
+public func manyTill<Out, Outs: RangeReplaceableCollectionType>(
+    parser: Result<Outs.Generator.Element>.Parser,
+    _ end: Result<Out>.Parser
+    ) -> Result<Outs>.Parser
+{
+    return fix { recur in {
+        (end *> { pure(Outs()) }) <|> { (cons <^> parser <*> { recur() }) }
+    }}()
+}
+
+/// Parses zero or more occurrences of `parser`.
+/// - Note: Returning parser never fails.
+public func skipMany<Out>(parser: Result<Out>.Parser) -> Result<()>.Parser {
+    return skipMany1(parser) <|> { pure(()) }
+}
+
+/// Parses one or more occurrences of `parser`.
+public func skipMany1<Out>(parser: Result<Out>.Parser) -> Result<()>.Parser {
+    return parser *> { skipMany(parser) }
+}
+
+/// Separates zero or more occurrences of `parser` using separator `separator`.
+/// - Note: Returning parser never fails.
+public func sepBy<Outs: RangeReplaceableCollectionType, Sep>(
+    parser: Result<Outs.Generator.Element>.Parser,
+    _ separator: Result<Sep>.Parser
+    ) -> Result<Outs>.Parser
+{
+    return sepBy1(parser, separator) <|> { pure(Outs()) }
+}
+
+/// Separates one or more occurrences of `parser` using separator `separator`.
+public func sepBy1<Outs: RangeReplaceableCollectionType, Sep>(
+    parser: Result<Outs.Generator.Element>.Parser,
+    _ separator: Result<Sep>.Parser
+    ) -> Result<Outs>.Parser
+{
+    return cons <^> parser <*> { many(separator *> { parser }) }
+}
+
+/// Separates zero or more occurrences of `parser` using optionally-ended separator `separator`.
+/// - Note: Returning parser never fails.
+public func sepEndBy<Outs: RangeReplaceableCollectionType, Sep>(
+    parser: Result<Outs.Generator.Element>.Parser,
+    _ separator: Result<Sep>.Parser
+    ) -> Result<Outs>.Parser
+{
+    return sepEndBy1(parser, separator) <|> { pure(Outs()) }
+}
+
+/// Separates one or more occurrences of `parser` using optionally-ended separator `separator`.
+public func sepEndBy1<Outs: RangeReplaceableCollectionType, Sep>(
+    parser: Result<Outs.Generator.Element>.Parser,
+    _ separator: Result<Sep>.Parser
+    ) -> Result<Outs>.Parser
+{
+    return parser >>- { x in
+        ((separator *> { sepEndBy(parser, separator) }) >>- { xs in
+            pure(Outs(x) + xs)
+        }) <|> { pure(Outs(x)) }
+    }
+}
+
+/// Parses `n` occurrences of `parser`.
+public func count<Outs: RangeReplaceableCollectionType>(
+    n: Int,
+    _ parser: Result<Outs.Generator.Element>.Parser
+    ) -> Result<Outs>.Parser
+{
+    guard n > 0 else { return pure(Outs()) }
+
+    return cons <^> parser <*> { count(n-1, parser) }
+}
+
+///
+/// Parses zero or more occurrences of `p`, separated by `op`
+/// which left-associates multiple outputs from `p` by applying its binary operation.
+///
+/// If there are zero occurrences of `p`, default value `x` is returned.
+///
+/// - Note: Returning parser never fails.
+///
+public func chainl<Out>(
+    p: Result<Out>.Parser,
+    _ op: Result<(Out, Out) -> Out>.Parser,
+    _ x: Out
+    ) -> Result<Out>.Parser
+{
+    return chainl1(p, op) <|> { pure(x) }
+}
+
+///
+/// Parses one or more occurrences of `p`, separated by `op`
+/// which left-associates multiple outputs from `p` by applying its binary operation.
+///
+/// This parser can be used to eliminate left recursion which typically occurs in expression grammars.
+///
+/// For example (pseudocode):
+///
+/// ```
+/// let expr = chainl1(term, symbol("-") *> pure(-))
+/// ```
+///
+/// can be interpretted as:
+///
+/// ```
+/// // [EBNF] expr = term { - term }
+/// let expr = curry({ $1.reduce($0, combine: -) }) <^> term <*> many(symbol("-") *> term)
+/// ```
+///
+/// but more efficient since `chainl1` doesn't use `many` to convert to
+/// `RangeReplaceableCollectionType` first and then `reduce`.
+///
+public func chainl1<Out>(
+    p: Result<Out>.Parser,
+    _ op: Result<(Out, Out) -> Out>.Parser
+    ) -> Result<Out>.Parser
+{
+    return p >>- { x in
+        fix { recur in { x in
+            (op >>- { f in
+                p >>- { y in
+                    recur(f(x, y))
+                }
+            }) <|> { pure(x)}
+        }}(x)
+    }
+}
+
+///
+/// Parses zero or more occurrences of `p`, separated by `op`
+/// which right-associates multiple outputs from `p` by applying its binary operation.
+///
+/// If there are zero occurrences of `p`, default value `x` is returned.
+///
+/// - Note: Returning parser never fails.
+///
+public func chainr<Out>(
+    p: Result<Out>.Parser,
+    _ op: Result<(Out, Out) -> Out>.Parser,
+    _ x: Out
+    ) -> Result<Out>.Parser
+{
+    return chainr1(p, op) <|> { pure(x) }
+}
+
+/// Parses one or more occurrences of `p`, separated by `op`
+/// which right-associates multiple outputs from `p` by applying its binary operation.
+public func chainr1<Out>(
+    p: Result<Out>.Parser,
+    _ op: Result<(Out, Out) -> Out>.Parser
+    ) -> Result<Out>.Parser
+{
+    return fix { recur in {
+        p >>- { x in
+            (op >>- { f in
+                recur() >>- { y in
+                    pure(f(x, y))
+                }
+            }) <|> { pure(x) }
+        }
+    }}()
+}
+
+/// Applies `parser` without consuming any input.
+public func lookAhead<Out>(parser: Result<Out>.Parser) -> Result<Out>.Parser
+{
+    return { input in
+        let reply = parser(input)
+        switch reply {
+        case .Fail:
+            return reply
+        case let .Done(_, output):
+            return .Done(input, output)
+        }
+    }
+}

--- a/Sources/TryParsecExperiment/Combinator.swift
+++ b/Sources/TryParsecExperiment/Combinator.swift
@@ -6,10 +6,24 @@ public func zeroOrOne<Out>(parser: Result<Out>.Parser) -> Result<Out?>.Parser {
 
 /// Parses zero or more occurrences of `parser`.
 /// - Note: Returning parser never fails.
-public func many<Outs: RangeReplaceableCollectionType>(parser: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
-    return many1(parser) <|> { pure(Outs()) }
+public func many<Outs: RangeReplaceableCollectionType>(p: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
+    return { input in
+        var result = Outs()
+        var remainder = input
+        while true {
+            switch parse(p, remainder) {
+            case .Done(let input, let out):
+                result.append(out)
+                remainder = input
+            case .Fail(_, _, _): return .Done(remainder, result)
+            }
+        }
+    }
 }
-
+//public func many<Outs: RangeReplaceableCollectionType>(parser: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
+//    return many1(parser) <|> { pure(Outs()) }
+//}
+//
 /// Parses one or more occurrences of `parser`.
 public func many1<Outs: RangeReplaceableCollectionType>(parser: Result<Outs.Generator.Element>.Parser) -> Result<Outs>.Parser {
     return cons <^> parser <*> { many(parser) }

--- a/Sources/TryParsecExperiment/Dictionary+Helper.swift
+++ b/Sources/TryParsecExperiment/Dictionary+Helper.swift
@@ -1,0 +1,9 @@
+/// Missing helper.
+internal func toDict<Key: Hashable, Value>(tuples: [(Key, Value)]) -> [Key : Value]
+{
+    var dict = [Key : Value]()
+    for tuple in tuples {
+        dict[tuple.0] = tuple.1
+    }
+    return dict
+}

--- a/Sources/TryParsecExperiment/DoubleType.swift
+++ b/Sources/TryParsecExperiment/DoubleType.swift
@@ -1,0 +1,36 @@
+internal protocol DoubleType
+{
+    var double: Double { get }
+
+    init(double: Double)
+}
+
+extension Int: DoubleType
+{
+    internal var double: Double { return Double(self) }
+
+    init(double: Double)
+    {
+        self = Int(double)
+    }
+}
+
+extension Float: DoubleType
+{
+    internal var double: Double { return Double(self) }
+
+    internal init(double: Double)
+    {
+        self = Float(double)
+    }
+}
+
+extension Double: DoubleType
+{
+    internal var double: Double { return self }
+
+    internal init(double: Double)
+    {
+        self = double
+    }
+}

--- a/Sources/TryParsecExperiment/FromJSON.swift
+++ b/Sources/TryParsecExperiment/FromJSON.swift
@@ -1,0 +1,196 @@
+import Result
+
+// MARK: decode
+
+/// Converts JSON string to `FromJSON` value.
+public func decode<FJ: FromJSON>(str: String) -> Result<FJ, JSON.ParseError>
+{
+    return parseOnly(json, str.unicodeScalars)
+        .mapError { _ in .InvalidJSONFormat }
+        .flatMap { FJ.fromJSON($0) }
+}
+
+// MARK: FromJSON
+
+public protocol FromJSON
+{
+    static func fromJSON(json: JSON) -> Result<Self, JSON.ParseError>
+}
+
+extension JSON: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<JSON, JSON.ParseError>
+    {
+        return .Success(json)
+    }
+}
+
+extension String: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<String, JSON.ParseError>
+    {
+        guard case let .String(v) = json else {
+            return typeMismatch(json, expected: "JSON.String")
+        }
+        return .Success(v)
+    }
+}
+
+// extension DoubleType where Self: FromJSON
+
+extension Int: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<Int, JSON.ParseError>
+    {
+        guard case let .Number(v) = json else {
+            return typeMismatch(json, expected: "JSON.Number")
+        }
+        return .Success(Int(v))
+    }
+}
+
+extension Float: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<Float, JSON.ParseError>
+    {
+        guard case let .Number(v) = json else {
+            return typeMismatch(json, expected: "JSON.Number")
+        }
+        return .Success(Float(v))
+    }
+}
+
+extension Double: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<Double, JSON.ParseError>
+    {
+        guard case let .Number(v) = json else {
+            return typeMismatch(json, expected: "JSON.Number")
+        }
+        return .Success(v)
+    }
+}
+
+extension Bool: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<Bool, JSON.ParseError>
+    {
+        guard case let .Bool(v) = json else {
+            return typeMismatch(json, expected: "JSON.Bool")
+        }
+        return .Success(v)
+    }
+}
+
+/// - Warning: Nested container is not supported.
+extension Array: FromJSON // where Element: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<[Element], JSON.ParseError>
+    {
+        guard case let .Array(jsons) = json else {
+            return typeMismatch(json, expected: "JSON.Array")
+        }
+
+        var arr = [Element]()
+        for json in jsons {
+            // Comment-Out: HKT i.e. `where Element: FromJSON` is required
+            // arr.append(Element.fromJSON(json))
+
+            // Warning: casting fails if `Element` is another container
+            if let elem = json.rawValue as? Element {
+                arr.append(elem)
+            }
+            else {
+                return .Failure(.TypeMismatched(expected: "\(Element.self)", actual: json.description))
+            }
+        }
+        return .Success(arr)
+    }
+}
+
+/// - Warning: Nested container is not supported.
+extension Dictionary: FromJSON // where Key == String, Value: FromJSON
+{
+    public static func fromJSON(json: JSON) -> Result<[Key : Value], JSON.ParseError>
+    {
+        guard case let .Object(jsons) = json else {
+            return typeMismatch(json, expected: "JSON.Object")
+        }
+
+        var dict = [Key : Value]()
+        for (key, json) in jsons {
+
+            // NOTE: this guard should not exist because `Key` should always be `String`
+            guard let key_ = key as? Key else {
+                fatalError("Should never reach here. (Dicitonary.Key is not String)")
+            }
+
+            // Comment-Out: HKT i.e. `where Value: FromJSON` is required
+            // dict[key_] = Value.fromJSON(json)
+
+            // Warning: casting fails if `Element` is another container
+            if let value = json.rawValue as? Value {
+                dict[key_] = value
+            }
+            else {
+                return .Failure(.TypeMismatched(expected: "\(Value.self)", actual: json.description))
+            }
+        }
+        return .Success(dict)
+    }
+}
+
+// MARK: FromJSON helpers
+
+/// Helper method to convert `JSON.Object` to `Result`.
+public func fromJSONObject<FJ: FromJSON>(json: JSON, mapper: [String : JSON] -> Result<FJ, JSON.ParseError>) -> Result<FJ, JSON.ParseError>
+{
+    guard case let .Object(dict) = json else {
+        return typeMismatch(json, expected: "JSON.Object")
+    }
+    return mapper(dict)
+}
+
+/// Extracts `FromJSON` value from `[String : JSON]` dictionary.
+public func !! <FJ: FromJSON>(dict: [String : JSON], key: String) -> Result<FJ, JSON.ParseError>
+{
+    if let json = dict[key] {
+        return FJ.fromJSON(json)
+    }
+    else {
+        return .Failure(.KeyNotFound(key))
+    }
+}
+
+///
+/// Extracts `FromJSON` value from `[String : JSON]` dictionary.
+///
+/// - Note:
+/// This is a workaround for `extension Optional`
+/// where `Self` and `Wrapped` can't constrain at same time.
+///
+public func !! <FJ: FromJSON>(dict: [String : JSON], key: String) -> Result<FJ?, JSON.ParseError>
+{
+    if let json = dict[key] {
+        if json == JSON.Null {
+            return .Success(nil)
+        }
+        else {
+            return FJ.fromJSON(json).map { Optional($0) }
+        }
+    }
+    else {
+        return .Failure(.KeyNotFound(key))
+    }
+}
+
+/// Optionally extracts `FromJSON` value from `[String : JSON]` dictionary.
+public func !? <FJ: FromJSON>(dict: [String : JSON], key: String) -> Result<FJ?, JSON.ParseError>
+{
+    if let json = dict[key] {
+        return FJ.fromJSON(json).map { Optional($0) }
+    }
+    else {
+        return .Success(nil)
+    }
+}

--- a/Sources/TryParsecExperiment/Info.plist
+++ b/Sources/TryParsecExperiment/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 Yasuhiro Inami. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/TryParsecExperiment/JSON.swift
+++ b/Sources/TryParsecExperiment/JSON.swift
@@ -1,0 +1,184 @@
+// MARK: JSON
+
+public enum JSON
+{
+    case String(Swift.String)
+    case Number(Double)
+    case Bool(Swift.Bool)
+    case Null
+    case Array([JSON])
+    case Object([Swift.String : JSON])
+}
+
+// MARK: RawRepresentable
+
+extension JSON: RawRepresentable
+{
+    public init?(rawValue: Any)
+    {
+        switch rawValue {
+            case let v as Swift.String:
+                self = .String(v)
+            case let v as DoubleType:
+                self = .Number(v.double)
+            case let v as Swift.Bool:
+                self = .Bool(v)
+            case is ():
+                self = .Null
+            case let v as [JSON]:
+                self = .Array(v)
+            case let v as [Swift.String : JSON]:
+                self = .Object(v)
+            default:
+                return nil
+        }
+    }
+
+    public var rawValue: Any
+    {
+        switch self {
+            case let .String(v): return v
+            case let .Number(v): return v
+            case let .Bool(v):   return v
+            case let .Null(v):   return v
+            case let .Array(v):  return v
+            case let .Object(v): return v
+        }
+    }
+}
+
+// MARK: Equatable
+
+extension JSON: Equatable {}
+
+public func == (lhs: JSON, rhs: JSON) -> Bool
+{
+    switch (lhs, rhs) {
+        case let (.String(l), .String(r)):
+            return l == r
+        case let (.Number(l), .Number(r)):
+            return l == r
+        case let (.Bool(l), .Bool(r)):
+            return l == r
+        case (.Null, .Null):
+            return true
+        case let (.Array(l), .Array(r)):
+            return l == r
+        case let (.Object(l), .Object(r)):
+            return l == r
+        default:
+            return false
+    }
+}
+
+// MARK: CustomStringConvertible
+
+extension JSON: CustomStringConvertible
+{
+    public var description: Swift.String
+    {
+        switch self {
+            case let .String(v):    return ".String(\(v))"
+            case let .Number(v):    return ".Number(\(v))"
+            case let .Bool(v):      return ".Bool(\(v))"
+            case .Null:             return ".Null"
+            case let .Array(v):     return ".Array(\(v.description))"
+            case let .Object(v):    return ".Object(\(v.description))"
+        }
+    }
+}
+
+// MARK: Accessors
+
+extension JSON
+{
+    public subscript(index: Int) -> JSON?
+    {
+        return self.rawArray?[index]
+    }
+
+    public subscript(key: Swift.String) -> JSON?
+    {
+        return self.rawObject?[key]
+    }
+
+    public var rawString: Swift.String?
+    {
+        switch self {
+            case let .String(v): return v
+            default: return nil
+        }
+    }
+
+    public var rawNumber: Double?
+    {
+        switch self {
+            case let .Number(v): return v
+            default: return nil
+        }
+    }
+
+    public var rawBool: Swift.Bool?
+    {
+        switch self {
+            case let .Bool(v): return v
+            default: return nil
+        }
+    }
+
+    public var rawNull: ()?
+    {
+        switch self {
+            case .Null: return ()
+            default: return nil
+        }
+    }
+
+    public var rawArray: [JSON]?
+    {
+        switch self {
+            case let .Array(v): return v
+            default: return nil
+        }
+    }
+
+    public var rawObject: [Swift.String : JSON]?
+    {
+        switch self {
+            case let .Object(v): return v
+            default: return nil
+        }
+    }
+
+    public var jsonString: Swift.String
+    {
+        switch self {
+            case let .String(v):    return "\"\(v)\""
+            case let .Number(v):    return "\(v)"
+            case let .Bool(v):      return "\(v)"
+            case .Null:             return "null"
+            case let .Array(v):
+                let valuesString = v.reduce("") {
+                    ($0 == "" ? "" : $0 + ", ") + $1.jsonString
+                }
+                return "[ " + valuesString + " ]"
+            case let .Object(v):
+                let keyValuesString = v.reduce("") {
+                    ($0 == "" ? "\"" : $0 + ", \"") + $1.0 + "\" : " + $1.1.jsonString
+                }
+                return "{ " + keyValuesString + " }"
+        }
+    }
+}
+
+// MARK: JSON.ParseError
+
+extension JSON
+{
+    public enum ParseError: ErrorType
+    {
+        case InvalidJSONFormat
+        case TypeMismatched(expected: Swift.String, actual: Swift.String)
+        case KeyNotFound(Swift.String)
+    }
+}

--- a/Sources/TryParsecExperiment/Operators+JSON.swift
+++ b/Sources/TryParsecExperiment/Operators+JSON.swift
@@ -1,0 +1,4 @@
+infix operator !!   { associativity left precedence 180 }
+infix operator !?   { associativity left precedence 180 }
+
+infix operator ~    { associativity left precedence 180 }

--- a/Sources/TryParsecExperiment/Operators.swift
+++ b/Sources/TryParsecExperiment/Operators.swift
@@ -1,0 +1,12 @@
+infix operator >>-  { associativity left precedence 100 }
+
+infix operator <|>  { associativity right precedence 130 }
+
+infix operator <*>  { associativity left precedence 140 }
+infix operator <*   { associativity left precedence 140 }
+infix operator *>   { associativity left precedence 140 }
+
+infix operator <^>  { associativity left precedence 140 }
+infix operator <&>  { associativity left precedence 140 }
+
+infix operator <?>  { associativity left precedence 0 }

--- a/Sources/TryParsecExperiment/Optional+Helper.swift
+++ b/Sources/TryParsecExperiment/Optional+Helper.swift
@@ -1,0 +1,8 @@
+extension Optional
+{
+    /// Haskell's `maybeToList`.
+    internal func toArray() -> [Wrapped]
+    {
+        return self != nil ? [self!] : []
+    }
+}

--- a/Sources/TryParsecExperiment/ParseError.swift
+++ b/Sources/TryParsecExperiment/ParseError.swift
@@ -1,0 +1,17 @@
+public enum ParseError: ErrorType
+{
+    case Message(String)
+//    case NotEnoughInput
+}
+
+extension ParseError: Equatable {}
+
+public func == (lhs: ParseError, rhs: ParseError) -> Bool
+{
+    switch (lhs, rhs) {
+        case let (.Message(msg1), .Message(msg2)):
+            return msg1 == msg2
+//        default:
+//            return false
+    }
+}

--- a/Sources/TryParsecExperiment/Parser+Arithmetic.swift
+++ b/Sources/TryParsecExperiment/Parser+Arithmetic.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Parses simple arithmetic expression.
+/// Currently supports: +, -, *, /, (, ), naturalNumber.
+public func parseArithmetic(str: String) -> Int? {
+    return parseOnly(_expr() <* { endOfInput() }, str.unicodeScalars)
+}
+
+private func _symbol(str: StringContainer) -> Result<StringContainer>.Parser {
+    return skipSpaces *> { string(str) } <* { skipSpaces }
+}
+
+private func _natural() -> Result<Int>.Parser {
+    return skipSpaces *> { many1(digit) } <* { skipSpaces } <&> { Int(String($0))! }
+}
+
+private func _expr() -> Result<Int>.Parser {
+    return chainl1(_term(), _symbol("+") *> { pure(+) } <|> { _symbol("-") *> { pure(-) }})
+}
+
+private func _term() -> Result<Int>.Parser {
+    return chainl1(_factor(), _symbol("*") *> { pure(*) } <|> { _symbol("/") *> { pure(/) }})
+}
+
+private func _factor() -> Result<Int>.Parser {
+    return (_symbol("(") *> { _expr() } <* { _symbol(")") }) <|> { _natural() }
+}

--- a/Sources/TryParsecExperiment/Parser+Arithmetic.swift
+++ b/Sources/TryParsecExperiment/Parser+Arithmetic.swift
@@ -1,27 +1,36 @@
-import Foundation
+import Result
 
 /// Parses simple arithmetic expression.
 /// Currently supports: +, -, *, /, (, ), naturalNumber.
-public func parseArithmetic(str: String) -> Int? {
+public func parseArithmetic(str: String) -> Result<Int, ParseError>
+{
     return parseOnly(_expr() <* { endOfInput() }, str.unicodeScalars)
 }
 
-private func _symbol(str: StringContainer) -> Result<StringContainer>.Parser {
+private func _symbol(str: StringContainer) -> Parser<StringContainer>.Function
+{
     return skipSpaces *> { string(str) } <* { skipSpaces }
 }
 
-private func _natural() -> Result<Int>.Parser {
+private func _natural() -> Parser<Int>.Function
+{
     return skipSpaces *> { many1(digit) } <* { skipSpaces } <&> { Int(String($0))! }
 }
 
-private func _expr() -> Result<Int>.Parser {
+internal let expr = _expr()
+private func _expr() -> Parser<Int>.Function
+{
     return chainl1(_term(), _symbol("+") *> { pure(+) } <|> { _symbol("-") *> { pure(-) }})
 }
 
-private func _term() -> Result<Int>.Parser {
+internal let term = _term()
+private func _term() -> Parser<Int>.Function
+{
     return chainl1(_factor(), _symbol("*") *> { pure(*) } <|> { _symbol("/") *> { pure(/) }})
 }
 
-private func _factor() -> Result<Int>.Parser {
+internal let factor = _factor()
+private func _factor() -> Parser<Int>.Function
+{
     return (_symbol("(") *> { _expr() } <* { _symbol(")") }) <|> { _natural() }
 }

--- a/Sources/TryParsecExperiment/Parser+Combinator.swift
+++ b/Sources/TryParsecExperiment/Parser+Combinator.swift
@@ -1,7 +1,7 @@
 /// Parses zero or one occurrence of `parser`.
 /// - SeeAlso: Haskell Parsec's `optionMaybe`.
 public func zeroOrOne<Out>(parser: Parser<Out>.Function) -> Parser<Out?>.Function {
-    return parser <&> Optional<Out>.init // <|> pure(Optional<Out>.None)
+    return parser <&> Optional<Out>.init <|> { pure(Optional<Out>.None) }
 }
 
 /// Parses zero or more occurrences of `parser`.

--- a/Sources/TryParsecExperiment/Parser+JSON.swift
+++ b/Sources/TryParsecExperiment/Parser+JSON.swift
@@ -1,37 +1,42 @@
+import Result
+
 //
 // JSON (ECMA-404)
 // http://json.org/
 //
 
 /// Parses JSON.
-public func parseJSON(str: String) -> JSON? {
+public func parseJSON(str: String) -> Result<JSON, ParseError>
+{
     return parseOnly(json, str.unicodeScalars)
 }
 
 /// Helper function to return `.Failure` from type-mismatched JSON.
-//public func typeMismatch<Expected>(json: JSON, expected: String) -> Result<Expected, JSON.ParseError>
-//{
-//    return .Failure(.TypeMismatched(expected: expected, actual: json.description))
-//}
+public func typeMismatch<Expected>(json: JSON, expected: String) -> Result<Expected, JSON.ParseError>
+{
+    return .Failure(.TypeMismatched(expected: expected, actual: json.description))
+}
 
 // MARK: Private
 
-internal let json = skipSpaces *> jsonValue <* { skipSpaces } <* { endOfInput() }
+internal let json = skipSpaces *> { jsonValue } <* { skipSpaces } <* { endOfInput() }
+internal let jsonValue = jsonString <|> { jsonNumber <|> { jsonArray <|> { jsonObject <|> { jsonNull <|> { jsonBool } } } } }
 
-private func jsonValue() -> Result<JSON>.Parser {
-    return jsonString() <|> { jsonNumber() <|> { jsonArray() <|> { jsonObject() <|> { jsonNull() <|> { jsonBool() } } } } }
-}
-
-private func jsonNull() -> Result<JSON>.Parser {
+internal let jsonNull = _jsonNull()
+private func _jsonNull() -> Parser<JSON>.Function
+{
     return string("null") *> { pure(.Null) }
 }
 
-private func jsonBool() -> Result<JSON>.Parser {
+internal let jsonBool = _jsonBool()
+private func _jsonBool() -> Parser<JSON>.Function
+{
     return (string("true") *> { pure(.Bool(true))} )
         <|> { (string("false") *> { pure(.Bool(false)) }) }
 }
 
-private func jsonNumber() -> Result<JSON>.Parser
+internal let jsonNumber = _jsonNumber()
+private func _jsonNumber() -> Parser<JSON>.Function
 {
     return number <&> JSON.Number
 }
@@ -50,7 +55,8 @@ private let _escapedCharMappingKeys = String.UnicodeScalarView(_escapedCharMappi
 
 /// Parses double-quoted text, e.g. `"123\n456"`.
 internal let stringLiteral = _stringLiteral()
-private func _stringLiteral() -> Result<StringContainer>.Parser {
+private func _stringLiteral() -> Parser<StringContainer>.Function
+{
     let normalChar = satisfy { $0 != "\\" && $0 != "\""}
     let escapedChar = char("\\")
         *> { oneOf(_escapedCharMappingKeys) }
@@ -63,34 +69,40 @@ private func _stringLiteral() -> Result<StringContainer>.Parser {
     return char("\"") *> { many(validChar) } <* { char("\"") }
 }
 
-private func jsonString() -> Result<JSON>.Parser {
+internal let jsonString = _jsonString()
+private func _jsonString() -> Parser<JSON>.Function
+{
     return stringLiteral <&> { JSON.String(String($0)) }
 }
 
 private func _list<A>(
-    open: Result<StringElement>.Parser,
-    _ close: Result<StringElement>.Parser,
-    _ element: Result<A>.Parser,
+    open: Parser<StringElement>.Function,
+    _ close: Parser<StringElement>.Function,
+    _ element: Parser<A>.Function,
     _ f: ([A] -> JSON)
-    ) -> Result<JSON>.Parser
+    ) -> Parser<JSON>.Function
 {
     return open *>
         { (skipSpaces *> { (sepBy(element <* { skipSpaces }, char(",") <* { skipSpaces }) <&> f) }) }
         <* { close }
 }
 
-private func jsonArray() -> Result<JSON>.Parser {
-    return _list(char("["), char("]"), jsonValue(), JSON.Array)
+internal let jsonArray = _jsonArray()
+private func _jsonArray() -> Parser<JSON>.Function
+{
+    return _list(char("["), char("]"), jsonValue, JSON.Array)
 }
 
 internal let keyValue = _keyValue()
-private func _keyValue() -> Result<(String.UnicodeScalarView, JSON)>.Parser {
+private func _keyValue() -> Parser<(StringContainer, JSON)>.Function
+{
     return { a in { b in (a, b) } }
         <^> stringLiteral
-        <*> { (skipSpaces *> { char(":") } *> { skipSpaces } *> jsonValue ) }
+        <*> { (skipSpaces *> { char(":") } *> { skipSpaces } *> { jsonValue }) }
 }
 
-private func jsonObject() -> Result<JSON>.Parser
+internal let jsonObject = _jsonObject()
+private func _jsonObject() -> Parser<JSON>.Function
 {
     return _list(char("{"), char("}"), keyValue) { tuples in
         JSON.Object(toDict(tuples.map { (String($0.0), $0.1) }))

--- a/Sources/TryParsecExperiment/Parser+JSON.swift
+++ b/Sources/TryParsecExperiment/Parser+JSON.swift
@@ -1,0 +1,98 @@
+//
+// JSON (ECMA-404)
+// http://json.org/
+//
+
+/// Parses JSON.
+public func parseJSON(str: String) -> JSON? {
+    return parseOnly(json, str.unicodeScalars)
+}
+
+/// Helper function to return `.Failure` from type-mismatched JSON.
+//public func typeMismatch<Expected>(json: JSON, expected: String) -> Result<Expected, JSON.ParseError>
+//{
+//    return .Failure(.TypeMismatched(expected: expected, actual: json.description))
+//}
+
+// MARK: Private
+
+internal let json = skipSpaces *> jsonValue <* { skipSpaces } <* { endOfInput() }
+
+private func jsonValue() -> Result<JSON>.Parser {
+    return jsonString() <|> { jsonNumber() <|> { jsonArray() <|> { jsonObject() <|> { jsonNull() <|> { jsonBool() } } } } }
+}
+
+private func jsonNull() -> Result<JSON>.Parser {
+    return string("null") *> { pure(.Null) }
+}
+
+private func jsonBool() -> Result<JSON>.Parser {
+    return (string("true") *> { pure(.Bool(true))} )
+        <|> { (string("false") *> { pure(.Bool(false)) }) }
+}
+
+private func jsonNumber() -> Result<JSON>.Parser
+{
+    return number <&> JSON.Number
+}
+
+private let _escapedCharMapping: [UnicodeScalar : UnicodeScalar] = [
+    "\"" : "\"",
+    "\\" : "\\",
+    "/" : "/",
+    "n" : "\n",
+    "r" : "\r",
+    "f" : "\u{8}",
+    "t" : "\t",
+    "b" : "\u{12}"
+]
+private let _escapedCharMappingKeys = String.UnicodeScalarView(_escapedCharMapping.keys)
+
+/// Parses double-quoted text, e.g. `"123\n456"`.
+internal let stringLiteral = _stringLiteral()
+private func _stringLiteral() -> Result<StringContainer>.Parser {
+    let normalChar = satisfy { $0 != "\\" && $0 != "\""}
+    let escapedChar = char("\\")
+        *> { oneOf(_escapedCharMappingKeys) }
+        <&> { _escapedCharMapping[$0]! }
+    let unicodeChar = string("\\u")
+        *> { count(4, hexDigit) }
+        <&> { UnicodeScalar(Int(String($0), radix: 16)!) }
+    let validChar = normalChar <|> { escapedChar <|> { unicodeChar } }
+
+    return char("\"") *> { many(validChar) } <* { char("\"") }
+}
+
+private func jsonString() -> Result<JSON>.Parser {
+    return stringLiteral <&> { JSON.String(String($0)) }
+}
+
+private func _list<A>(
+    open: Result<StringElement>.Parser,
+    _ close: Result<StringElement>.Parser,
+    _ element: Result<A>.Parser,
+    _ f: ([A] -> JSON)
+    ) -> Result<JSON>.Parser
+{
+    return open *>
+        { (skipSpaces *> { (sepBy(element <* { skipSpaces }, char(",") <* { skipSpaces }) <&> f) }) }
+        <* { close }
+}
+
+private func jsonArray() -> Result<JSON>.Parser {
+    return _list(char("["), char("]"), jsonValue(), JSON.Array)
+}
+
+internal let keyValue = _keyValue()
+private func _keyValue() -> Result<(String.UnicodeScalarView, JSON)>.Parser {
+    return { a in { b in (a, b) } }
+        <^> stringLiteral
+        <*> { (skipSpaces *> { char(":") } *> { skipSpaces } *> jsonValue ) }
+}
+
+private func jsonObject() -> Result<JSON>.Parser
+{
+    return _list(char("{"), char("}"), keyValue) { tuples in
+        JSON.Object(toDict(tuples.map { (String($0.0), $0.1) }))
+    }
+}

--- a/Sources/TryParsecExperiment/Parser+UnicodeScalarView.swift
+++ b/Sources/TryParsecExperiment/Parser+UnicodeScalarView.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+
+/// MARK: Parser
+
+/// Parses one StringElement that passes `predicate`.
+public func satisfy(predicate: StringElement -> Bool) -> Result<StringElement>.Parser {
+    return { input in
+        if let head = input.first where predicate(head) {
+            return .Done(input.dropFirst(), head)
+        } else {
+            return .Fail(input, [], "satisfy")
+        }
+    }
+}
+
+/// Skips one StringElement that passes `predicate`.
+public func skip(predicate: StringElement -> Bool) -> Result<()>.Parser {
+    return { input in
+        if let head = input.first where predicate(head) {
+            return .Done(input.dropFirst(), ())
+        } else {
+            return .Fail(input, [], "skip")
+        }
+    }
+}
+
+/// Skips zero or more StringElement that passes `predicate`.
+public func skipWhile(predicate: StringElement -> Bool) -> Result<()>.Parser {
+    return { input in
+        fix { recur in { input in
+            if let head = input.first where predicate(head) {
+                return recur(input.dropFirst())
+            } else {
+                return .Done(input, ())
+            }
+        }}(input)
+    }
+}
+
+/// Parses at maximum of `count` StringElement.
+/// - Precondition: `count >= 0`
+public func take(count: Int) -> Result<StringContainer>.Parser {
+    precondition(count >= 0, "`take(count)` requires `count >= 0`.")
+
+    return { input in
+        if input.count >= count {
+            let (prefix, suffix) = splitAt(count)(input)
+            return .Done(suffix, prefix)
+        } else {
+            return .Fail(input, [], "take(\(count))")
+        }
+    }
+}
+
+/// Parses zero or more StringElement that passes `predicate`.
+public func takeWhile(predicate: StringElement -> Bool) -> Result<StringContainer>.Parser {
+    return { input in
+        fix { recur in { input, acc in
+            if let head = input.first where predicate(head) {
+                return recur(input.dropFirst(), acc + [head])
+            } else {
+                return .Done(input, acc)
+            }
+        }}(input, StringContainer())
+    }
+}
+
+/// Parses any one StringElement.
+public let any = satisfy(const(true))
+
+/// Parses one StringElement matching `c`.
+public func char(c: StringElement) -> Result<StringElement>.Parser {
+    return satisfy { $0 == c }
+}
+
+/// Parses any one StringElement which doesn't match `c`.
+public func not(c: StringElement) -> Result<StringElement>.Parser {
+    return satisfy { $0 != c }
+}
+
+/// Parses given string `str`.
+public func string(str: StringContainer) -> Result<StringContainer>.Parser {
+    if let head = str.first {
+        return char(head) *> { string(str.dropFirst()) } *> { pure(str) }
+    } else {
+        return pure(StringContainer())
+    }
+}
+
+/// Parses one StringElement which `xs` contains.
+public func oneOf(xs: StringContainer) -> Result<StringElement>.Parser {
+    return satisfy{ xs.contains($0) }
+}
+
+/// Parses one StringElement which `xs` doesn't contain.
+public func noneOf(xs: StringContainer) -> Result<StringElement>.Parser {
+    return satisfy { !xs.contains($0) }
+}
+
+/// Parses one digit StringElement which is in `"0"..."9"`.
+public let digit = satisfy(isDigit)
+public func isDigit(character: StringElement) -> Bool {
+    return "0"..."9" ~= character
+}
+
+/// Parses one StringElement which is in `"0"..."9"` or `"a"..."f"`.
+public let hexDigit = satisfy(isHexDigit)
+public func isHexDigit(c: StringElement) -> Bool {
+    return "0"..."9" ~= c || "a"..."f" ~= c || "A"..."F" ~= c
+}
+
+/// Parses one StringElement which is in `"a"..."z"`.
+public let lowerAlphabet = satisfy(isLowerAlphabet)
+public func isLowerAlphabet(c: StringElement) -> Bool {
+    return "a"..."z" ~= c
+}
+
+/// Parses one StringElement which is in `"A"..."Z"`.
+public let upperAlphabet = satisfy(isUpperAlphabet)
+public func isUpperAlphabet(c: StringElement) -> Bool {
+    return "A"..."Z" ~= c
+}
+
+/// Parses one alphabet letter (case-insensitive).
+public let alphabet = lowerAlphabet <|> { upperAlphabet }
+
+/// Parses one alphabet (case-insensitive) or digit.
+public let alphaNum = alphabet <|> { digit }
+
+/// Parses first StringElement which is in `[" ", "\t", "\n", "\r"]`.
+public let space = satisfy(isSpace)
+public func isSpace(character: StringElement) -> Bool {
+    return [" ", "\t", "\n", "\r"].contains(character)
+}
+
+/// Skips zero or more occurrences of `space`.
+public let skipSpaces = skipMany(space)
+
+/// Matches either a single newline character '\n',
+/// or a carriage return followed by a newline character "\r\n".
+public let endOfLine = char("\n") *> { pure(()) } <|> { string("\r\n") *> { pure(()) } }
+
+// MARK: String -> Number
+
+private func _signed<N: SignedNumberType>() -> Result<N -> N>.Parser {
+    return char("-") *> { pure(negate) }
+        <|> { zeroOrOne(char("+")) *> { pure(id) } }
+}
+
+private func _real() -> Result<Double>.Parser {
+    return many1(digit) >>- { digits in
+        pure(Double(String(digits))!)
+    }
+}
+
+private func _frac() -> Result<Double>.Parser {
+    return (char(".")
+        *> { many1(digit) } >>- { digits in
+            pure(Double(String(cons("0")(cons(".")(digits))))!)
+        }) <|> { pure(0.0) }
+}
+
+private func _exp() -> Result<Int>.Parser {
+    return (oneOf("eE")
+        *> { _signed() } >>- { doExp in
+            many1(digit) >>- { digits in
+                pure(doExp(Int(String(digits))!))
+            }
+        }) <|> { pure(0) }
+}
+
+///
+/// Parses a scientific-E-notation number.
+///
+/// For example:
+/// - `parse(number, "-12.5e-1")` will output `-1.25`
+///
+public let number = _number()
+private func _number() -> Result<Double>.Parser {
+    return { s in { r in { f in { e in s(r + f) * pow(10, Double(e)) } } } }
+        <^> _signed()
+        <*> { _real() }
+        <*> { _frac() }
+        <*> { _exp() }
+}

--- a/Sources/TryParsecExperiment/Parser+UnicodeScalarView.swift
+++ b/Sources/TryParsecExperiment/Parser+UnicodeScalarView.swift
@@ -4,7 +4,7 @@ import Foundation
 /// MARK: Parser
 
 /// Parses one StringElement that passes `predicate`.
-public func satisfy(predicate: StringElement -> Bool) -> Result<StringElement>.Parser {
+public func satisfy(predicate: StringElement -> Bool) -> Parser<StringElement>.Function {
     return { input in
         if let head = input.first where predicate(head) {
             return .Done(input.dropFirst(), head)
@@ -15,7 +15,7 @@ public func satisfy(predicate: StringElement -> Bool) -> Result<StringElement>.P
 }
 
 /// Skips one StringElement that passes `predicate`.
-public func skip(predicate: StringElement -> Bool) -> Result<()>.Parser {
+public func skip(predicate: StringElement -> Bool) -> Parser<()>.Function {
     return { input in
         if let head = input.first where predicate(head) {
             return .Done(input.dropFirst(), ())
@@ -26,7 +26,7 @@ public func skip(predicate: StringElement -> Bool) -> Result<()>.Parser {
 }
 
 /// Skips zero or more StringElement that passes `predicate`.
-public func skipWhile(predicate: StringElement -> Bool) -> Result<()>.Parser {
+public func skipWhile(predicate: StringElement -> Bool) -> Parser<()>.Function {
     return { input in
         fix { recur in { input in
             if let head = input.first where predicate(head) {
@@ -40,7 +40,7 @@ public func skipWhile(predicate: StringElement -> Bool) -> Result<()>.Parser {
 
 /// Parses at maximum of `count` StringElement.
 /// - Precondition: `count >= 0`
-public func take(count: Int) -> Result<StringContainer>.Parser {
+public func take(count: Int) -> Parser<StringContainer>.Function {
     precondition(count >= 0, "`take(count)` requires `count >= 0`.")
 
     return { input in
@@ -54,7 +54,7 @@ public func take(count: Int) -> Result<StringContainer>.Parser {
 }
 
 /// Parses zero or more StringElement that passes `predicate`.
-public func takeWhile(predicate: StringElement -> Bool) -> Result<StringContainer>.Parser {
+public func takeWhile(predicate: StringElement -> Bool) -> Parser<StringContainer>.Function {
     return { input in
         fix { recur in { input, acc in
             if let head = input.first where predicate(head) {
@@ -70,17 +70,17 @@ public func takeWhile(predicate: StringElement -> Bool) -> Result<StringContaine
 public let any = satisfy(const(true))
 
 /// Parses one StringElement matching `c`.
-public func char(c: StringElement) -> Result<StringElement>.Parser {
+public func char(c: StringElement) -> Parser<StringElement>.Function {
     return satisfy { $0 == c }
 }
 
 /// Parses any one StringElement which doesn't match `c`.
-public func not(c: StringElement) -> Result<StringElement>.Parser {
+public func not(c: StringElement) -> Parser<StringElement>.Function {
     return satisfy { $0 != c }
 }
 
 /// Parses given string `str`.
-public func string(str: StringContainer) -> Result<StringContainer>.Parser {
+public func string(str: StringContainer) -> Parser<StringContainer>.Function {
     if let head = str.first {
         return char(head) *> { string(str.dropFirst()) } *> { pure(str) }
     } else {
@@ -88,39 +88,59 @@ public func string(str: StringContainer) -> Result<StringContainer>.Parser {
     }
 }
 
+private func _string(str: StringContainer, _ f: StringElement -> StringElement) -> Parser<StringContainer>.Function
+{
+    return { input in
+        let strCount = str.count
+        let prefix = input.prefix(strCount)
+        if prefix.map(f) == str.map(f) {
+            let suffix = input.suffixFrom(input.startIndex.advancedBy(strCount))
+            return .Done(suffix, prefix)
+        }
+        else {
+            return .Fail(input, [], "_string")
+        }
+    }
+}
+
+/// Parses given ASCII-string `str` with case-insensitive match.
+public func asciiCI(str: StringContainer) -> Parser<StringContainer>.Function
+{
+    return _string(str, { c in
+        let value = c.value
+
+        // if `c` is in `"a"..."z"` (lowercase)
+        if 97...122 ~= value {
+            // transform to uppercase
+            return UnicodeScalar(value - 32)  // ord 'a' - ord 'A' = 97 - 65 = 32
+        }
+        else {
+            return c
+        }
+    })
+}
+
 /// Parses one StringElement which `xs` contains.
-public func oneOf(xs: StringContainer) -> Result<StringElement>.Parser {
+public func oneOf(xs: StringContainer) -> Parser<StringElement>.Function {
     return satisfy{ xs.contains($0) }
 }
 
 /// Parses one StringElement which `xs` doesn't contain.
-public func noneOf(xs: StringContainer) -> Result<StringElement>.Parser {
+public func noneOf(xs: StringContainer) -> Parser<StringElement>.Function {
     return satisfy { !xs.contains($0) }
 }
 
 /// Parses one digit StringElement which is in `"0"..."9"`.
 public let digit = satisfy(isDigit)
-public func isDigit(character: StringElement) -> Bool {
-    return "0"..."9" ~= character
-}
 
 /// Parses one StringElement which is in `"0"..."9"` or `"a"..."f"`.
 public let hexDigit = satisfy(isHexDigit)
-public func isHexDigit(c: StringElement) -> Bool {
-    return "0"..."9" ~= c || "a"..."f" ~= c || "A"..."F" ~= c
-}
 
 /// Parses one StringElement which is in `"a"..."z"`.
 public let lowerAlphabet = satisfy(isLowerAlphabet)
-public func isLowerAlphabet(c: StringElement) -> Bool {
-    return "a"..."z" ~= c
-}
 
 /// Parses one StringElement which is in `"A"..."Z"`.
 public let upperAlphabet = satisfy(isUpperAlphabet)
-public func isUpperAlphabet(c: StringElement) -> Bool {
-    return "A"..."Z" ~= c
-}
 
 /// Parses one alphabet letter (case-insensitive).
 public let alphabet = lowerAlphabet <|> { upperAlphabet }
@@ -130,9 +150,6 @@ public let alphaNum = alphabet <|> { digit }
 
 /// Parses first StringElement which is in `[" ", "\t", "\n", "\r"]`.
 public let space = satisfy(isSpace)
-public func isSpace(character: StringElement) -> Bool {
-    return [" ", "\t", "\n", "\r"].contains(character)
-}
 
 /// Skips zero or more occurrences of `space`.
 public let skipSpaces = skipMany(space)
@@ -143,25 +160,25 @@ public let endOfLine = char("\n") *> { pure(()) } <|> { string("\r\n") *> { pure
 
 // MARK: String -> Number
 
-private func _signed<N: SignedNumberType>() -> Result<N -> N>.Parser {
+private func _signed<N: SignedNumberType>() -> Parser<N -> N>.Function {
     return char("-") *> { pure(negate) }
         <|> { zeroOrOne(char("+")) *> { pure(id) } }
 }
 
-private func _real() -> Result<Double>.Parser {
+private func _real() -> Parser<Double>.Function {
     return many1(digit) >>- { digits in
         pure(Double(String(digits))!)
     }
 }
 
-private func _frac() -> Result<Double>.Parser {
+private func _frac() -> Parser<Double>.Function {
     return (char(".")
         *> { many1(digit) } >>- { digits in
             pure(Double(String(cons("0")(cons(".")(digits))))!)
         }) <|> { pure(0.0) }
 }
 
-private func _exp() -> Result<Int>.Parser {
+private func _exp() -> Parser<Int>.Function {
     return (oneOf("eE")
         *> { _signed() } >>- { doExp in
             many1(digit) >>- { digits in
@@ -177,7 +194,7 @@ private func _exp() -> Result<Int>.Parser {
 /// - `parse(number, "-12.5e-1")` will output `-1.25`
 ///
 public let number = _number()
-private func _number() -> Result<Double>.Parser {
+private func _number() -> Parser<Double>.Function {
     return { s in { r in { f in { e in s(r + f) * pow(10, Double(e)) } } } }
         <^> _signed()
         <*> { _real() }

--- a/Sources/TryParsecExperiment/Prelude.swift
+++ b/Sources/TryParsecExperiment/Prelude.swift
@@ -16,9 +16,9 @@ internal func negate<N: SignedNumberType>(x: N) -> N {
 /// Haskell `(:)` (cons operator) for replacing slow `[x] + xs`.
 internal func cons<C: RangeReplaceableCollectionType>(x: C.Generator.Element) -> C -> C {
     return { xs in
-        var xs = xs
-        xs.insert(x, atIndex: xs.startIndex)
-        return xs
+        var x = C(x)
+        x.appendContentsOf(xs)
+        return x
     }
 }
 

--- a/Sources/TryParsecExperiment/Prelude.swift
+++ b/Sources/TryParsecExperiment/Prelude.swift
@@ -1,0 +1,49 @@
+/// Identity function.
+internal func id<A>(a: A) -> A {
+    return a
+}
+
+/// Constant function.
+internal func const<A, B>(a: A) -> B -> A {
+    return { _ in a }
+}
+
+/// Unary negation.
+internal func negate<N: SignedNumberType>(x: N) -> N {
+    return -x
+}
+
+/// Haskell `(:)` (cons operator) for replacing slow `[x] + xs`.
+internal func cons<C: RangeReplaceableCollectionType>(x: C.Generator.Element) -> C -> C {
+    return { xs in
+        var xs = xs
+        xs.insert(x, atIndex: xs.startIndex)
+        return xs
+    }
+}
+
+/// Extracts head and tail of `CollectionType`, returning nil if it is empty.
+internal func uncons<C: CollectionType>(xs: C) -> (C.Generator.Element, C.SubSequence)? {
+    if let head = xs.first {
+        return (head, xs.dropFirst())
+    } else {
+        return nil
+    }
+}
+
+/// `splitAt(count)(xs)` returns a tuple of `xs.prefixUpTo(count)` and `suffixFrom(count)`,
+/// but either of those may be empty.
+/// - Precondition: `count >= 0`
+internal func splitAt<C: CollectionType>(count: C.Index.Distance) -> C -> (C.SubSequence, C.SubSequence) {
+    precondition(count >= 0, "`splitAt(count)` must have `count >= 0`.")
+
+    return { xs in
+        let midIndex = xs.startIndex.advancedBy(count, limit: xs.endIndex)
+        return (xs.prefixUpTo(midIndex), xs.suffixFrom(midIndex))
+    }
+}
+
+/// Fixed-point combinator.
+internal func fix<T, U>(f: (T -> U) -> T -> U) -> T -> U {
+    return { f(fix(f))($0) }
+}

--- a/Sources/TryParsecExperiment/Prelude.swift
+++ b/Sources/TryParsecExperiment/Prelude.swift
@@ -16,9 +16,9 @@ internal func negate<N: SignedNumberType>(x: N) -> N {
 /// Haskell `(:)` (cons operator) for replacing slow `[x] + xs`.
 internal func cons<C: RangeReplaceableCollectionType>(x: C.Generator.Element) -> C -> C {
     return { xs in
-        var x = C(x)
-        x.appendContentsOf(xs)
-        return x
+        var xs = xs
+        xs.insert(x, atIndex: xs.startIndex)
+        return xs
     }
 }
 

--- a/Sources/TryParsecExperiment/RangeReplaceableCollectionType+Helper.swift
+++ b/Sources/TryParsecExperiment/RangeReplaceableCollectionType+Helper.swift
@@ -1,0 +1,20 @@
+extension RangeReplaceableCollectionType
+{
+    /// Missing initializer.
+    public init(_ x: Self.Generator.Element)
+    {
+        self.init()
+        self.append(x)
+    }
+
+//#if !SWIFT_PACKAGE
+//#if swift(>=2.2)
+//#else
+    /// Missing initializer until Swift 2.1.
+    public init<S: SequenceType where S.Generator.Element == Self.Generator.Element>(_ xs: S)
+    {
+        self.init()
+        self.appendContentsOf(xs)
+    }
+//#endif
+}

--- a/Sources/TryParsecExperiment/Result.swift
+++ b/Sources/TryParsecExperiment/Result.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+public typealias StringContainer = String.UnicodeScalarView
+public typealias StringElement = String.UnicodeScalarView.Generator.Element
+
+extension StringContainer {
+    /// Faster override
+    func dropFirst() -> SubSequence {
+        return suffixFrom(startIndex.successor())
+    }
+}
+
+extension StringContainer: StringLiteralConvertible {
+    public init(stringLiteral value: String) {
+        self = value.unicodeScalars
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self = value.unicodeScalars
+    }
+
+    public init(unicodeScalarLiteral value: String) {
+        self = value.unicodeScalars
+    }
+}
+
+/// Runs a parser `p`.
+/// - Returns: `Reply<In, Out>`
+public func parse<Out>(parser: Result<Out>.Parser, _ input: StringContainer) -> Result<Out> {
+    return parser(input)
+}
+
+/// Runs a parser `p` that cannot be resupplied via a 'Partial' reply.
+/// - Returns: `Result<Out, ParseError>`
+public func parseOnly<Out>(p: Result<Out>.Parser, _ input: StringContainer) -> Out? {
+    return parse(p, input).result
+}
+
+/// MARK: Result
+public enum Result<Out> {
+    /// The parse failed
+    /// - Parameter In: the input that had not yet been consumed when failure occured
+    /// - Parameter [String]: a list of contexts in which error occured
+    /// - Parameter String: the message describing the error
+    case Fail(In, [String], String)
+
+    /// The parse succeeded
+    /// - Parameter In: the input that had not yet been consumed
+    case Done(In, Out)
+
+    public typealias In = StringContainer
+    public typealias Parser = In -> Result<Out>
+}
+
+extension Result {
+    var result: Out? {
+        guard case let .Done(_, output) = self else { return nil }
+        return output
+    }
+
+    public func map<Out2>(f: Out -> Out2) -> Result<Out2> {
+        switch self {
+        case let .Fail(input, contexts, message):
+            return .Fail(input, contexts, message)
+        case let .Done(input, output):
+            return .Done(input, f(output))
+        }
+    }
+}
+
+/// Haskell's `<$>` or `fmap`, Swift's `map`.
+public func <^> <Out1, Out2>(f: Out1 -> Out2, result: Result<Out1>) -> Result<Out2> {
+    return result.map(f)
+}
+
+// MARK: Monad
+
+public func fail<Out>(message: String) -> Result<Out>.Parser {
+    return { .Fail($0, [], message) }
+}
+
+/// Haskell's `>>=` & Swift's `flatMap`.
+public func >>- <Out1, Out2>(parser: Result<Out1>.Parser, f: Out1 -> Result<Out2>.Parser) -> Result<Out2>.Parser {
+    return { input in
+        switch parser(input) {
+        case let .Fail(input2, contexts, message):
+            return .Fail(input2, contexts, message)
+        case let .Done(input2, output):
+            return f(output)(input2)
+        }
+    }
+}
+
+// MARK: Alternative
+
+/// The identity of `<|>`.
+public func empty<Out>() -> Result<Out>.Parser {
+    return fail("empty")
+}
+
+/// Alternation, choice.
+/// Uses `q` only if `p` failed.
+public func <|> <Out>(parser1: Result<Out>.Parser, parser2: () -> Result<Out>.Parser) -> Result<Out>.Parser {
+    return { input in
+        let result = parser1(input)
+        switch result {
+        case .Fail:
+            return parser2()(input)
+        case .Done:
+            return result
+        }
+    }
+}
+
+// MARK: Applicative
+
+/// Lifts `output` to `Parser`.
+public func pure<Out>(output: Out) -> Result<Out>.Parser {
+    return { .Done($0, output) }
+}
+
+/// Sequential application.
+public func <*> <Out1, Out2>(parser1: Result<Out1 -> Out2>.Parser, parser2: () -> Result<Out1>.Parser) -> Result<Out2>.Parser {
+    return { input in
+        switch parser1(input) {
+        case let .Fail(input2, contexts, message):
+            return .Fail(input2, contexts, message)
+        case let .Done(input2, f):
+            switch parser2()(input2) {
+            case let .Fail(input3, contexts, message):
+                return .Fail(input3, contexts, message)
+            case let .Done(input3, output3):
+                return .Done(input3, f(output3))
+            }
+        }
+    }
+}
+
+/// Sequence actions, discarding right (value of the second argument).
+public func <* <Out1, Out2>(parser1: Result<Out1>.Parser, parser2: () -> Result<Out2>.Parser) -> Result<Out1>.Parser {
+    return { input in
+        switch parser1(input) {
+        case let .Fail(input2, contexts, message):
+            return .Fail(input2, contexts, message)
+        case let .Done(input2, output2):
+            switch parser2()(input2) {
+            case let .Fail(input3, contexts, message):
+                return .Fail(input3, contexts, message)
+            case let .Done(input3, _):
+                return .Done(input3, output2)
+            }
+        }
+    }
+}
+
+/// Sequence actions, discarding left (value of the first argument).
+public func *> <Out1, Out2>(parser1: Result<Out1>.Parser, parser2: () -> Result<Out2>.Parser) -> Result<Out2>.Parser {
+    return { input in
+        switch parser1(input) {
+        case let .Fail(input2, contexts, message):
+            return .Fail(input2, contexts, message)
+        case let .Done(input2, _):
+            return parser2()(input2)
+        }
+    }
+}
+
+// MARK: Functor
+
+/// Haskell's `<$>` or `fmap`, Swift's `map`.
+public func <^> <Out1, Out2>(f: Out1 -> Out2, parser: Result<Out1>.Parser) -> Result<Out2>.Parser {
+    return { input in
+        switch parser(input) {
+        case let .Fail(input2, contexts, message):
+            return .Fail(input2, contexts, message)
+        case let .Done(input2, output):
+            return .Done(input2, f(output))
+        }
+    }
+}
+
+/// Argument-flipped `<^>`, i.e. `flip(<^>)`.
+public func <&> <Out1, Out2>(parser: Result<Out1>.Parser, f: Out1 -> Out2) -> Result<Out2>.Parser {
+    return f <^> parser
+}
+
+// MARK: Label
+
+/// Adds name to parser.
+public func <?> <Out>(parser: Result<Out>.Parser, label: () -> String) -> Result<Out>.Parser {
+    return { input in
+        let reply = parser(input)
+        switch reply {
+        case .Done:
+            return reply
+        case let .Fail(input2, labels, message2):
+            return .Fail(input2, [label()] + labels, message2)
+        }
+    }
+}
+
+// MARK: Peek
+
+/// Matches any first element to perform lookahead.
+public func peek() -> Result<StringElement>.Parser {
+    return { input in
+        if let head = input.first {
+            return .Done(input, head)
+        } else {
+            return .Fail(input, [], "peek")
+        }
+    }
+}
+
+/// Matches only if all input has been consumed.
+public func endOfInput() -> Result<()>.Parser {
+    return { input in
+        if input.isEmpty {
+            return .Done(input, ())
+        } else {
+            return .Fail(input, [], "endOfInput")
+        }
+    }
+}

--- a/Sources/TryParsecExperiment/Sepcialized+Combinator.swift
+++ b/Sources/TryParsecExperiment/Sepcialized+Combinator.swift
@@ -27,12 +27,12 @@ internal func cons(x: StringElement) -> StringContainer -> StringContainer
 
 /// Parses zero or more occurrences of `parser`.
 /// - Note: Returning parser never fails.
-public func many(p: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+public func many(parser: Parser<StringElement>.Function) -> Parser<StringContainer>.Function {
     return { input in
         var result = StringContainer()
         var remainder = input
         while true {
-            switch parse(p, remainder) {
+            switch parser(remainder) {
             case .Done(let input, let out):
                 result.append(out)
                 remainder = input
@@ -41,21 +41,21 @@ public func many(p: Result<StringElement>.Parser) -> Result<StringContainer>.Par
         }
     }
 }
-//public func many(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+//public func many(parser: Parser<StringElement>.Function) -> Parser<StringContainer>.Function {
 //    return many1(parser) <|> { pure(StringContainer()) }
 //}
 //
 /// Parses one or more occurrences of `parser`.
-public func many1(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+public func many1(parser: Parser<StringElement>.Function) -> Parser<StringContainer>.Function {
     return cons <^> parser <*> { many(parser) }
 }
 
 /// Parses one or more occurrences of `parser` until `end` succeeds,
 /// and returns the list of values returned by `parser`.
 public func manyTill<Out>(
-    parser: Result<StringElement>.Parser,
-    _ end: Result<Out>.Parser
-    ) -> Result<StringContainer>.Parser
+    parser: Parser<StringElement>.Function,
+    _ end: Parser<Out>.Function
+    ) -> Parser<StringContainer>.Function
 {
     return fix { recur in {
         (end *> { pure(StringContainer()) }) <|> { (cons <^> parser <*> { recur() }) }
@@ -65,18 +65,18 @@ public func manyTill<Out>(
 /// Separates zero or more occurrences of `parser` using separator `separator`.
 /// - Note: Returning parser never fails.
 public func sepBy(
-    parser: Result<StringElement>.Parser,
-    _ separator: Result<StringElement>.Parser
-    ) -> Result<StringContainer>.Parser
+    parser: Parser<StringElement>.Function,
+    _ separator: Parser<StringElement>.Function
+    ) -> Parser<StringContainer>.Function
 {
     return sepBy1(parser, separator) <|> { pure(StringContainer()) }
 }
 
 /// Separates one or more occurrences of `parser` using separator `separator`.
 public func sepBy1(
-    parser: Result<StringElement>.Parser,
-    _ separator: Result<StringElement>.Parser
-    ) -> Result<StringContainer>.Parser
+    parser: Parser<StringElement>.Function,
+    _ separator: Parser<StringElement>.Function
+    ) -> Parser<StringContainer>.Function
 {
     return cons <^> parser <*> { many(separator *> { parser }) }
 }
@@ -84,8 +84,8 @@ public func sepBy1(
 /// Parses `n` occurrences of `parser`.
 public func count(
     n: Int,
-    _ parser: Result<StringElement>.Parser
-    ) -> Result<StringContainer>.Parser
+    _ parser: Parser<StringElement>.Function
+    ) -> Parser<StringContainer>.Function
 {
     guard n > 0 else { return pure(StringContainer()) }
 

--- a/Sources/TryParsecExperiment/Sepcialized+Prelude.swift
+++ b/Sources/TryParsecExperiment/Sepcialized+Prelude.swift
@@ -27,10 +27,24 @@ internal func cons(x: StringElement) -> StringContainer -> StringContainer
 
 /// Parses zero or more occurrences of `parser`.
 /// - Note: Returning parser never fails.
-public func many(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
-    return many1(parser) <|> { pure(StringContainer()) }
+public func many(p: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+    return { input in
+        var result = StringContainer()
+        var remainder = input
+        while true {
+            switch parse(p, remainder) {
+            case .Done(let input, let out):
+                result.append(out)
+                remainder = input
+            case .Fail(_, _, _): return .Done(remainder, result)
+            }
+        }
+    }
 }
-
+//public func many(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+//    return many1(parser) <|> { pure(StringContainer()) }
+//}
+//
 /// Parses one or more occurrences of `parser`.
 public func many1(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
     return cons <^> parser <*> { many(parser) }

--- a/Sources/TryParsecExperiment/Sepcialized+Prelude.swift
+++ b/Sources/TryParsecExperiment/Sepcialized+Prelude.swift
@@ -1,0 +1,79 @@
+///// Haskell `(:)` (cons operator) for replacing slow `[x] + xs`.
+//internal func cons(x: StringElement) -> StringContainer -> StringContainer {
+//    return { xs in
+//        var xs = xs
+//        xs.insert(x, atIndex: xs.startIndex)
+//        return xs
+//    }
+//}
+//
+///// Extracts head and tail of `CollectionType`, returning nil if it is empty.
+//internal func uncons(xs: StringContainer) -> (StringElement, StringContainer)? {
+//    if let head = xs.first {
+//        return (head, xs.dropFirst())
+//    } else {
+//        return nil
+//    }
+//}
+//
+internal func cons(x: StringElement) -> StringContainer -> StringContainer
+{
+    return { xs in
+        var x = StringContainer(x)
+        x.appendContentsOf(xs)
+        return x
+    }
+}
+
+/// Parses zero or more occurrences of `parser`.
+/// - Note: Returning parser never fails.
+public func many(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+    return many1(parser) <|> { pure(StringContainer()) }
+}
+
+/// Parses one or more occurrences of `parser`.
+public func many1(parser: Result<StringElement>.Parser) -> Result<StringContainer>.Parser {
+    return cons <^> parser <*> { many(parser) }
+}
+
+/// Parses one or more occurrences of `parser` until `end` succeeds,
+/// and returns the list of values returned by `parser`.
+public func manyTill<Out>(
+    parser: Result<StringElement>.Parser,
+    _ end: Result<Out>.Parser
+    ) -> Result<StringContainer>.Parser
+{
+    return fix { recur in {
+        (end *> { pure(StringContainer()) }) <|> { (cons <^> parser <*> { recur() }) }
+        }}()
+}
+
+/// Separates zero or more occurrences of `parser` using separator `separator`.
+/// - Note: Returning parser never fails.
+public func sepBy(
+    parser: Result<StringElement>.Parser,
+    _ separator: Result<StringElement>.Parser
+    ) -> Result<StringContainer>.Parser
+{
+    return sepBy1(parser, separator) <|> { pure(StringContainer()) }
+}
+
+/// Separates one or more occurrences of `parser` using separator `separator`.
+public func sepBy1(
+    parser: Result<StringElement>.Parser,
+    _ separator: Result<StringElement>.Parser
+    ) -> Result<StringContainer>.Parser
+{
+    return cons <^> parser <*> { many(separator *> { parser }) }
+}
+
+/// Parses `n` occurrences of `parser`.
+public func count(
+    n: Int,
+    _ parser: Result<StringElement>.Parser
+    ) -> Result<StringContainer>.Parser
+{
+    guard n > 0 else { return pure(StringContainer()) }
+
+    return cons <^> parser <*> { count(n-1, parser) }
+}

--- a/Sources/TryParsecExperiment/ToJSON.swift
+++ b/Sources/TryParsecExperiment/ToJSON.swift
@@ -1,0 +1,211 @@
+// MARK: encode
+
+/// Converts `input` (which conforms to `ToJSON` protocol) to JSON string.
+public func encode<TJ: ToJSON>(input: TJ) -> String
+{
+    return TJ.toJSON(input).jsonString
+}
+
+// MARK: ToJSON
+
+public protocol ToJSON
+{
+    static func toJSON(value: Self) -> JSON
+}
+
+extension JSON: ToJSON
+{
+    public static func toJSON(value: JSON) -> JSON
+    {
+        return value
+    }
+}
+
+extension String: ToJSON
+{
+    public static func toJSON(value: String) -> JSON
+    {
+        return JSON.String(value)
+    }
+}
+
+extension Int: ToJSON
+{
+    public static func toJSON(value: Int) -> JSON
+    {
+        return JSON.Number(value.double)
+    }
+}
+
+extension Float: ToJSON
+{
+    public static func toJSON(value: Float) -> JSON
+    {
+        return JSON.Number(value.double)
+    }
+}
+
+extension Double: ToJSON
+{
+    public static func toJSON(value: Double) -> JSON
+    {
+        return JSON.Number(value.double)
+    }
+}
+
+extension Bool: ToJSON
+{
+    public static func toJSON(value: Bool) -> JSON
+    {
+        return JSON.Bool(value)
+    }
+}
+
+/// - Warning: Nested container is not supported.
+extension Array: ToJSON // where Element: ToJSON
+{
+    public static func toJSON(arr: [Element]) -> JSON
+    {
+        return _reflectToJSON(arr)
+    }
+}
+
+/// - Warning: Nested container is not supported.
+extension Dictionary: ToJSON // where Key == String, Value: ToJSON
+{
+    public static func toJSON(dict: Dictionary) -> JSON
+    {
+        return _reflectToJSON(dict)
+    }
+}
+
+extension Optional /*: ToJSON */ where Wrapped: ToJSON
+{
+    public static func toJSON(value: Optional) -> JSON
+    {
+        if let value = value {
+            return Wrapped.toJSON(value)
+        }
+        else {
+            return JSON.Null
+        }
+    }
+}
+
+///
+/// Workaround for `ToJSON`-container types (Array/Dictionary)
+/// to let their elements also behave as `ToJSON` instance by using Mirror (reflection).
+///
+/// - TODO: Remove this once HKT is supported.
+///
+private func _reflectToJSON(anyValue: Any) -> JSON
+{
+    //
+    // Comment-Out & Limitation & FIXME:
+    //
+    // `anyValue` can't be convert to `ToJSON` protocol due to compile error:
+    //
+    //   "Error: Protocol 'ToJSON' can only be used as a generic constraint because it has Self or associated type requirements"
+    //
+    // This means, user-custom `ToJSON` instance e.g. `extension NSURL: ToJSON`
+    // which is wrapped into some Array/Dictionary container e.g. `let urls: [NSURL]`
+    // **can't be treated as `ToJSON` instance** (due to lack of HKT support).
+    //
+    // Therefore, current `ToJSON` is limited in its usage in Swift 2,
+    // so consider using some full-reflection alternatives
+    // e.g. https://github.com/inamiy/ToAnyObject for any types.
+    //
+//    // use user-implemented `toJSON()` if possible
+//    if let anyValue = anyValue as? ToJSON {
+//        return ToJSON.toJSON(anyValue)
+//    }
+
+    let mirror = Mirror(reflecting: anyValue)
+
+    switch mirror.displayStyle {
+
+        case .Some(.Optional):
+
+            return mirror.children.first.map { _reflectToJSON($0.1) } ?? JSON.Null
+
+        //
+        // Comment-Out:
+        // This should never reach here because subModel (struct or class) must be
+        // wrapped with some container (Array/Dictionary) before
+        // (`_reflectToJSON()` is used for only those cases).
+        //
+        // If mirror it, subModel's `toJSON` will never be used.
+        //
+//        case .Some(.Struct), .Some(.Class):
+//
+//            var dict = [String : JSON]()
+//            for (key, value) in mirror.children {
+//                guard let key = key else { continue }
+//                dict[key] = _reflectToJSON(value)
+//            }
+//            return JSON.Object(dict)
+
+        case .Some(.Collection):    // e.g. Array
+
+            let jsons = mirror.children.map { _reflectToJSON($1) }
+            return JSON.Array(jsons)
+
+        case .Some(.Dictionary):    // e.g. Dictionary
+
+            var dict: [String : JSON] = [:]
+            for (_, keyValue) in mirror.children {
+
+                if let (key, json) = keyValue as? (String, JSON) {
+                    dict[key] = json
+                }
+                // NOTE: ObjC-type-tuple casting i.e. `keyValue as? (String, AnyObject)` doesn't work
+                else if let (key, value) = keyValue as? (String, Any) {
+                    dict[key] = _reflectToJSON(value)
+                }
+                else {
+                    fatalError("`_reflectToJSON()` failed. (Using ObjC types inside Dictionary? Internal value was \(keyValue).)")
+                }
+            }
+            return JSON.Object(dict)
+
+        default:
+
+            // nearly equivalent to `return ToJSON.toJSON(anyValue)` for primitive types
+            switch anyValue {
+                case let value as JSON:
+                    return value
+                case let value as String:
+                    return String.toJSON(value)
+                case let value as DoubleType:
+                    return Double.toJSON(value.double)
+                case let value as Bool:
+                    return Bool.toJSON(value)
+                case is ():
+                    return JSON.Null
+                default:
+                    fatalError("`_reflectToJSON()` failed. (Using custom `ToJSON` instance inside Array/Dictionary? Internal value was \(anyValue).)")
+            }
+    }
+
+}
+
+// MARK: ToJSON helpers
+
+/// Helper method to convert array of `(key, jsonValue)` to `JSON.Object`.
+public func toJSONObject(keyValues: [(String, JSON)]) -> JSON
+{
+    return JSON.Object(toDict(keyValues))
+}
+
+/// Creates key-JSONValue tuple from key-rawValue.
+public func ~ <TJ: ToJSON>(key: String, value: TJ) -> (String, JSON)
+{
+    return (key, TJ.toJSON(value))
+}
+
+/// Workaround for `extension Optional`
+/// where `Self` and `Wrapped` can't constrain at same time.
+public func ~ <TJ: ToJSON>(key: String, value: TJ?) -> (String, JSON)
+{
+    return (key, Optional.toJSON(value))
+}

--- a/Sources/TryParsecExperiment/TryParsecExperiment.h
+++ b/Sources/TryParsecExperiment/TryParsecExperiment.h
@@ -1,0 +1,19 @@
+//
+//  TryParsecExperiment.h
+//  TryParsecExperiment
+//
+//  Created by 野村 憲男 on 3/10/16.
+//  Copyright © 2016 Yasuhiro Inami. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for TryParsecExperiment.
+FOUNDATION_EXPORT double TryParsecExperimentVersionNumber;
+
+//! Project version string for TryParsecExperiment.
+FOUNDATION_EXPORT const unsigned char TryParsecExperimentVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <TryParsecExperiment/PublicHeader.h>
+
+

--- a/Sources/TryParsecExperiment/UnicodeScalarView+Helper.swift
+++ b/Sources/TryParsecExperiment/UnicodeScalarView+Helper.swift
@@ -1,0 +1,112 @@
+extension String.UnicodeScalarView: StringLiteralConvertible
+{
+    public init(stringLiteral value: String)
+    {
+        self = value.unicodeScalars
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String)
+    {
+        self = value.unicodeScalars
+    }
+
+    public init(unicodeScalarLiteral value: String)
+    {
+        self = value.unicodeScalars
+    }
+}
+
+extension String.UnicodeScalarView: ArrayLiteralConvertible
+{
+    public init(arrayLiteral elements: UnicodeScalar...)
+    {
+        self.init()
+        self.appendContentsOf(elements)
+    }
+}
+
+extension String.UnicodeScalarView: Equatable {}
+
+public func == (lhs: String.UnicodeScalarView, rhs: String.UnicodeScalarView) -> Bool
+{
+    return String(lhs) == String(rhs)
+}
+
+// MARK: Functions
+
+public func isDigit(c: UnicodeScalar) -> Bool
+{
+    return "0"..."9" ~= c
+}
+
+public func isHexDigit(c: UnicodeScalar) -> Bool
+{
+    return "0"..."9" ~= c || "a"..."f" ~= c || "A"..."F" ~= c
+}
+
+public func isLowerAlphabet(c: UnicodeScalar) -> Bool
+{
+    return "a"..."z" ~= c
+}
+
+public func isUpperAlphabet(c: UnicodeScalar) -> Bool
+{
+    return "A"..."Z" ~= c
+}
+
+public func isAlphabet(c: UnicodeScalar) -> Bool
+{
+    return isLowerAlphabet(c) || isUpperAlphabet(c)
+}
+
+private let _spaces: String.UnicodeScalarView = [ " ", "\t", "\n", "\r" ]
+
+public func isSpace(c: UnicodeScalar) -> Bool
+{
+    return _spaces.contains(c)
+}
+
+/// UnicodeScalar validation using array of `ClosedInterval`.
+public func isInClosedIntervals(c: UnicodeScalar, _ closedIntervals: ClosedInterval<UInt32>...) -> Bool
+{
+    for closedInterval in closedIntervals {
+        if closedInterval.contains(c.value) {
+            return true
+        }
+    }
+    return false
+}
+
+/// Removes head & tail whitespaces.
+public func trim(cs: String.UnicodeScalarView) -> String.UnicodeScalarView
+{
+    return _trim(cs, true, true)
+}
+
+/// Removes head whitespace.
+public func trimStart(cs: String.UnicodeScalarView) -> String.UnicodeScalarView
+{
+    return _trim(cs, true, false)
+}
+
+/// Removes tail whitespace.
+public func trimEnd(cs: String.UnicodeScalarView) -> String.UnicodeScalarView
+{
+    return _trim(cs, false, true)
+}
+
+private func _trim(cs: String.UnicodeScalarView, _ trimsStart: Bool, _ trimsEnd: Bool) -> String.UnicodeScalarView
+{
+    var startIndex = cs.startIndex
+    var endIndex = cs.endIndex.predecessor()
+
+    while trimsStart && isSpace(cs[startIndex]) {
+        startIndex = startIndex.successor()
+    }
+
+    while trimsEnd && isSpace(cs[endIndex]) {
+        endIndex = endIndex.predecessor()
+    }
+
+    return cs[startIndex...endIndex]
+}

--- a/TryParsec.xcodeproj/project.pbxproj
+++ b/TryParsec.xcodeproj/project.pbxproj
@@ -68,14 +68,23 @@
 		1FF4207B1C41684B00F69CBA /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4207A1C41684B00F69CBA /* Curry.framework */; };
 		1FF4207C1C41685300F69CBA /* TryParsec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE8E41F1B896E9100E1F2D0 /* TryParsec.framework */; };
 		481906FD1B8B48CF0046BD8A /* Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481906FC1B8B48CF0046BD8A /* Prelude.swift */; };
+		6C1657D71C930CE400100972 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26EC1C91577900500F93 /* PerformanceTests.swift */; };
+		6C1657E51C930ED800100972 /* Sepcialized+Combinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26411C914DD900500F93 /* Sepcialized+Combinator.swift */; };
+		6C1657FC1C930FAD00100972 /* XCTestCase+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26901C91544C00500F93 /* XCTestCase+Helper.swift */; };
+		6C1658041C9310FC00100972 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E268E1C91544C00500F93 /* TestHelper.swift */; };
+		6C1658091C93110500100972 /* HelperSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26951C91544C00500F93 /* HelperSpec.swift */; };
+		6C16580A1C93110800100972 /* ParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26971C91544C00500F93 /* ParserSpec.swift */; };
+		6C16580B1C93110A00100972 /* CombinatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26931C91544C00500F93 /* CombinatorSpec.swift */; };
+		6C16580C1C93110D00100972 /* UnicodeScalarViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26981C91544C00500F93 /* UnicodeScalarViewSpec.swift */; };
+		6C16580D1C93111000100972 /* ArithmeticSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26921C91544C00500F93 /* ArithmeticSpec.swift */; };
+		6C16580F1C93111600100972 /* JSONSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26961C91544C00500F93 /* JSONSpec.swift */; };
 		6C2E25F61C914A2D00500F93 /* TryParsecExperiment.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6C2E25FD1C914A2D00500F93 /* TryParsecExperiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C2E25F31C914A2D00500F93 /* TryParsecExperiment.framework */; };
-		6C2E262C1C914C7E00500F93 /* Combinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26291C914C7E00500F93 /* Combinator.swift */; };
-		6C2E262D1C914C7E00500F93 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E262A1C914C7E00500F93 /* Result.swift */; };
+		6C2E262C1C914C7E00500F93 /* Parser+Combinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26291C914C7E00500F93 /* Parser+Combinator.swift */; };
+		6C2E262D1C914C7E00500F93 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E262A1C914C7E00500F93 /* Parser.swift */; };
 		6C2E262E1C914C7E00500F93 /* Parser+UnicodeScalarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */; };
 		6C2E26421C914DD900500F93 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E263F1C914DD900500F93 /* Operators.swift */; };
 		6C2E26431C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */; };
-		6C2E26441C914DD900500F93 /* Sepcialized+Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */; };
 		6C2E264B1C914DE500500F93 /* Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26471C914DE500500F93 /* Prelude.swift */; };
 		6C2E264C1C914DE500500F93 /* DoubleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26481C914DE500500F93 /* DoubleType.swift */; };
 		6C2E264D1C914DE500500F93 /* Optional+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26491C914DE500500F93 /* Optional+Helper.swift */; };
@@ -89,8 +98,11 @@
 		6C2E26661C914F0700500F93 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F06BDCE1C4A7C1C001250BE /* Nimble.framework */; };
 		6C2E26671C914F0700500F93 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F06BDCC1C4A7C18001250BE /* Quick.framework */; };
 		6C2E26681C914F0700500F93 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4207A1C41684B00F69CBA /* Curry.framework */; };
-		6C2E26EA1C91576800500F93 /* XCTestCase+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26901C91544C00500F93 /* XCTestCase+Helper.swift */; };
-		6C2E26ED1C91577900500F93 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26EC1C91577900500F93 /* PerformanceTests.swift */; };
+		6CF496F01C92CE0A008498D7 /* ParseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF496EC1C92CDE9008498D7 /* ParseError.swift */; };
+		6CF496F41C92CE20008498D7 /* Operators+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF496E11C92CC4D008498D7 /* Operators+JSON.swift */; };
+		6CF496F71C92CE26008498D7 /* FromJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF496E51C92CC69008498D7 /* FromJSON.swift */; };
+		6CF496FA1C92CE2A008498D7 /* ToJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF496E61C92CC69008498D7 /* ToJSON.swift */; };
+		6CF4973A1C92D32B008498D7 /* UnicodeScalarView+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF497351C92D325008498D7 /* UnicodeScalarView+Helper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -189,18 +201,18 @@
 		6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TryParsecExperiment.h; sourceTree = "<group>"; };
 		6C2E25F71C914A2D00500F93 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6C2E25FC1C914A2D00500F93 /* TryParsecExperimentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TryParsecExperimentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6C2E26291C914C7E00500F93 /* Combinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Combinator.swift; sourceTree = "<group>"; };
-		6C2E262A1C914C7E00500F93 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
-		6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+UnicodeScalarView.swift"; sourceTree = "<group>"; };
+		6C2E26291C914C7E00500F93 /* Parser+Combinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Parser+Combinator.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		6C2E262A1C914C7E00500F93 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Parser+UnicodeScalarView.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6C2E263F1C914DD900500F93 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollectionType+Helper.swift"; sourceTree = "<group>"; };
-		6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sepcialized+Prelude.swift"; sourceTree = "<group>"; };
+		6C2E26411C914DD900500F93 /* Sepcialized+Combinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sepcialized+Combinator.swift"; sourceTree = "<group>"; };
 		6C2E26471C914DE500500F93 /* Prelude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prelude.swift; sourceTree = "<group>"; };
 		6C2E26481C914DE500500F93 /* DoubleType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleType.swift; sourceTree = "<group>"; };
 		6C2E26491C914DE500500F93 /* Optional+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Helper.swift"; sourceTree = "<group>"; };
 		6C2E264A1C914DE500500F93 /* Dictionary+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Helper.swift"; sourceTree = "<group>"; };
-		6C2E26521C914E0200500F93 /* Parser+Arithmetic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+Arithmetic.swift"; sourceTree = "<group>"; };
-		6C2E26561C914E2300500F93 /* Parser+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+JSON.swift"; sourceTree = "<group>"; };
+		6C2E26521C914E0200500F93 /* Parser+Arithmetic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Parser+Arithmetic.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		6C2E26561C914E2300500F93 /* Parser+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Parser+JSON.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6C2E26571C914E2300500F93 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		6C2E268E1C91544C00500F93 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		6C2E268F1C91544C00500F93 /* TestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModel.swift; sourceTree = "<group>"; };
@@ -214,6 +226,11 @@
 		6C2E26981C91544C00500F93 /* UnicodeScalarViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnicodeScalarViewSpec.swift; sourceTree = "<group>"; };
 		6C2E26991C91544C00500F93 /* XMLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLSpec.swift; sourceTree = "<group>"; };
 		6C2E26EC1C91577900500F93 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
+		6CF496E11C92CC4D008498D7 /* Operators+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operators+JSON.swift"; sourceTree = "<group>"; };
+		6CF496E51C92CC69008498D7 /* FromJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FromJSON.swift; sourceTree = "<group>"; };
+		6CF496E61C92CC69008498D7 /* ToJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToJSON.swift; sourceTree = "<group>"; };
+		6CF496EC1C92CDE9008498D7 /* ParseError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseError.swift; sourceTree = "<group>"; };
+		6CF497351C92D325008498D7 /* UnicodeScalarView+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnicodeScalarView+Helper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -504,10 +521,11 @@
 			isa = PBXGroup;
 			children = (
 				6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */,
-				6C2E26291C914C7E00500F93 /* Combinator.swift */,
+				6C2E262A1C914C7E00500F93 /* Parser.swift */,
+				6C2E26291C914C7E00500F93 /* Parser+Combinator.swift */,
 				6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */,
-				6C2E262A1C914C7E00500F93 /* Result.swift */,
-				6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */,
+				6CF496EC1C92CDE9008498D7 /* ParseError.swift */,
+				6C2E26411C914DD900500F93 /* Sepcialized+Combinator.swift */,
 				6C2E26351C914C9B00500F93 /* Basic */,
 				6C2E26501C914DEA00500F93 /* Arithmetic */,
 				6C2E26551C914E0D00500F93 /* JSON */,
@@ -522,6 +540,7 @@
 			children = (
 				6C2E263F1C914DD900500F93 /* Operators.swift */,
 				6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */,
+				6CF497351C92D325008498D7 /* UnicodeScalarView+Helper.swift */,
 				6C2E26361C914CAE00500F93 /* Internals */,
 			);
 			name = Basic;
@@ -549,8 +568,11 @@
 		6C2E26551C914E0D00500F93 /* JSON */ = {
 			isa = PBXGroup;
 			children = (
+				6CF496E11C92CC4D008498D7 /* Operators+JSON.swift */,
 				6C2E26561C914E2300500F93 /* Parser+JSON.swift */,
 				6C2E26571C914E2300500F93 /* JSON.swift */,
+				6CF496E51C92CC69008498D7 /* FromJSON.swift */,
+				6CF496E61C92CC69008498D7 /* ToJSON.swift */,
 			);
 			name = JSON;
 			sourceTree = "<group>";
@@ -917,16 +939,21 @@
 				6C2E264C1C914DE500500F93 /* DoubleType.swift in Sources */,
 				6C2E26591C914E2300500F93 /* JSON.swift in Sources */,
 				6C2E262E1C914C7E00500F93 /* Parser+UnicodeScalarView.swift in Sources */,
+				6C1657E51C930ED800100972 /* Sepcialized+Combinator.swift in Sources */,
 				6C2E26421C914DD900500F93 /* Operators.swift in Sources */,
+				6CF496FA1C92CE2A008498D7 /* ToJSON.swift in Sources */,
 				6C2E264E1C914DE500500F93 /* Dictionary+Helper.swift in Sources */,
+				6CF496F71C92CE26008498D7 /* FromJSON.swift in Sources */,
 				6C2E26531C914E0200500F93 /* Parser+Arithmetic.swift in Sources */,
-				6C2E262D1C914C7E00500F93 /* Result.swift in Sources */,
-				6C2E26441C914DD900500F93 /* Sepcialized+Prelude.swift in Sources */,
-				6C2E262C1C914C7E00500F93 /* Combinator.swift in Sources */,
+				6C2E262D1C914C7E00500F93 /* Parser.swift in Sources */,
+				6C2E262C1C914C7E00500F93 /* Parser+Combinator.swift in Sources */,
+				6CF496F01C92CE0A008498D7 /* ParseError.swift in Sources */,
 				6C2E26431C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift in Sources */,
 				6C2E264D1C914DE500500F93 /* Optional+Helper.swift in Sources */,
 				6C2E26581C914E2300500F93 /* Parser+JSON.swift in Sources */,
 				6C2E264B1C914DE500500F93 /* Prelude.swift in Sources */,
+				6CF4973A1C92D32B008498D7 /* UnicodeScalarView+Helper.swift in Sources */,
+				6CF496F41C92CE20008498D7 /* Operators+JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -934,8 +961,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6C2E26EA1C91576800500F93 /* XCTestCase+Helper.swift in Sources */,
-				6C2E26ED1C91577900500F93 /* PerformanceTests.swift in Sources */,
+				6C16580B1C93110A00100972 /* CombinatorSpec.swift in Sources */,
+				6C16580C1C93110D00100972 /* UnicodeScalarViewSpec.swift in Sources */,
+				6C1658041C9310FC00100972 /* TestHelper.swift in Sources */,
+				6C16580A1C93110800100972 /* ParserSpec.swift in Sources */,
+				6C1657FC1C930FAD00100972 /* XCTestCase+Helper.swift in Sources */,
+				6C1658091C93110500100972 /* HelperSpec.swift in Sources */,
+				6C1657D71C930CE400100972 /* PerformanceTests.swift in Sources */,
+				6C16580D1C93111000100972 /* ArithmeticSpec.swift in Sources */,
+				6C16580F1C93111600100972 /* JSONSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1184,6 +1218,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Sources/TryParsecExperiment/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/TryParsec.xcodeproj/project.pbxproj
+++ b/TryParsec.xcodeproj/project.pbxproj
@@ -68,6 +68,29 @@
 		1FF4207B1C41684B00F69CBA /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4207A1C41684B00F69CBA /* Curry.framework */; };
 		1FF4207C1C41685300F69CBA /* TryParsec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE8E41F1B896E9100E1F2D0 /* TryParsec.framework */; };
 		481906FD1B8B48CF0046BD8A /* Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481906FC1B8B48CF0046BD8A /* Prelude.swift */; };
+		6C2E25F61C914A2D00500F93 /* TryParsecExperiment.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6C2E25FD1C914A2D00500F93 /* TryParsecExperiment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C2E25F31C914A2D00500F93 /* TryParsecExperiment.framework */; };
+		6C2E262C1C914C7E00500F93 /* Combinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26291C914C7E00500F93 /* Combinator.swift */; };
+		6C2E262D1C914C7E00500F93 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E262A1C914C7E00500F93 /* Result.swift */; };
+		6C2E262E1C914C7E00500F93 /* Parser+UnicodeScalarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */; };
+		6C2E26421C914DD900500F93 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E263F1C914DD900500F93 /* Operators.swift */; };
+		6C2E26431C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */; };
+		6C2E26441C914DD900500F93 /* Sepcialized+Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */; };
+		6C2E264B1C914DE500500F93 /* Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26471C914DE500500F93 /* Prelude.swift */; };
+		6C2E264C1C914DE500500F93 /* DoubleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26481C914DE500500F93 /* DoubleType.swift */; };
+		6C2E264D1C914DE500500F93 /* Optional+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26491C914DE500500F93 /* Optional+Helper.swift */; };
+		6C2E264E1C914DE500500F93 /* Dictionary+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E264A1C914DE500500F93 /* Dictionary+Helper.swift */; };
+		6C2E26531C914E0200500F93 /* Parser+Arithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26521C914E0200500F93 /* Parser+Arithmetic.swift */; };
+		6C2E26581C914E2300500F93 /* Parser+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26561C914E2300500F93 /* Parser+JSON.swift */; };
+		6C2E26591C914E2300500F93 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26571C914E2300500F93 /* JSON.swift */; };
+		6C2E26611C914EDE00500F93 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FC183B21C6AC24100FB1EC9 /* Result.framework */; };
+		6C2E26641C914EF800500F93 /* TestAssets in Resources */ = {isa = PBXBuildFile; fileRef = 1FB5C1C21C829B790063B2EF /* TestAssets */; };
+		6C2E26651C914F0700500F93 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FC183B21C6AC24100FB1EC9 /* Result.framework */; };
+		6C2E26661C914F0700500F93 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F06BDCE1C4A7C1C001250BE /* Nimble.framework */; };
+		6C2E26671C914F0700500F93 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F06BDCC1C4A7C18001250BE /* Quick.framework */; };
+		6C2E26681C914F0700500F93 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4207A1C41684B00F69CBA /* Curry.framework */; };
+		6C2E26EA1C91576800500F93 /* XCTestCase+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26901C91544C00500F93 /* XCTestCase+Helper.swift */; };
+		6C2E26ED1C91577900500F93 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E26EC1C91577900500F93 /* PerformanceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +114,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1FE8E41E1B896E9100E1F2D0;
 			remoteInfo = Parser;
+		};
+		6C2E25FE1C914A2D00500F93 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1FE8E4161B896E9100E1F2D0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6C2E25F21C914A2D00500F93;
+			remoteInfo = TryParsecExperiment;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -155,6 +185,35 @@
 		1FF420751C41678D00F69CBA /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		1FF4207A1C41684B00F69CBA /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = Carthage/Checkouts/Curry/build/Debug/Curry.framework; sourceTree = "<group>"; };
 		481906FC1B8B48CF0046BD8A /* Prelude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prelude.swift; sourceTree = "<group>"; };
+		6C2E25F31C914A2D00500F93 /* TryParsecExperiment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TryParsecExperiment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TryParsecExperiment.h; sourceTree = "<group>"; };
+		6C2E25F71C914A2D00500F93 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C2E25FC1C914A2D00500F93 /* TryParsecExperimentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TryParsecExperimentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E26291C914C7E00500F93 /* Combinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Combinator.swift; sourceTree = "<group>"; };
+		6C2E262A1C914C7E00500F93 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+UnicodeScalarView.swift"; sourceTree = "<group>"; };
+		6C2E263F1C914DD900500F93 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollectionType+Helper.swift"; sourceTree = "<group>"; };
+		6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sepcialized+Prelude.swift"; sourceTree = "<group>"; };
+		6C2E26471C914DE500500F93 /* Prelude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prelude.swift; sourceTree = "<group>"; };
+		6C2E26481C914DE500500F93 /* DoubleType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleType.swift; sourceTree = "<group>"; };
+		6C2E26491C914DE500500F93 /* Optional+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Helper.swift"; sourceTree = "<group>"; };
+		6C2E264A1C914DE500500F93 /* Dictionary+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Helper.swift"; sourceTree = "<group>"; };
+		6C2E26521C914E0200500F93 /* Parser+Arithmetic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+Arithmetic.swift"; sourceTree = "<group>"; };
+		6C2E26561C914E2300500F93 /* Parser+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+JSON.swift"; sourceTree = "<group>"; };
+		6C2E26571C914E2300500F93 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		6C2E268E1C91544C00500F93 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
+		6C2E268F1C91544C00500F93 /* TestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModel.swift; sourceTree = "<group>"; };
+		6C2E26901C91544C00500F93 /* XCTestCase+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Helper.swift"; sourceTree = "<group>"; };
+		6C2E26921C91544C00500F93 /* ArithmeticSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArithmeticSpec.swift; sourceTree = "<group>"; };
+		6C2E26931C91544C00500F93 /* CombinatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinatorSpec.swift; sourceTree = "<group>"; };
+		6C2E26941C91544C00500F93 /* CSVSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSVSpec.swift; sourceTree = "<group>"; };
+		6C2E26951C91544C00500F93 /* HelperSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelperSpec.swift; sourceTree = "<group>"; };
+		6C2E26961C91544C00500F93 /* JSONSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSpec.swift; sourceTree = "<group>"; };
+		6C2E26971C91544C00500F93 /* ParserSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserSpec.swift; sourceTree = "<group>"; };
+		6C2E26981C91544C00500F93 /* UnicodeScalarViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnicodeScalarViewSpec.swift; sourceTree = "<group>"; };
+		6C2E26991C91544C00500F93 /* XMLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLSpec.swift; sourceTree = "<group>"; };
+		6C2E26EC1C91577900500F93 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +256,26 @@
 				1FF4207B1C41684B00F69CBA /* Curry.framework in Frameworks */,
 				1F06BDCD1C4A7C18001250BE /* Quick.framework in Frameworks */,
 				1F06BDCF1C4A7C1C001250BE /* Nimble.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25EF1C914A2D00500F93 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E26611C914EDE00500F93 /* Result.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25F91C914A2D00500F93 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E25FD1C914A2D00500F93 /* TryParsecExperiment.framework in Frameworks */,
+				6C2E26651C914F0700500F93 /* Result.framework in Frameworks */,
+				6C2E26661C914F0700500F93 /* Nimble.framework in Frameworks */,
+				6C2E26671C914F0700500F93 /* Quick.framework in Frameworks */,
+				6C2E26681C914F0700500F93 /* Curry.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -340,6 +419,8 @@
 				1FE8E4211B896E9100E1F2D0 /* Sources */,
 				1FE8E42D1B896E9100E1F2D0 /* Tests */,
 				1FC182501C6AC19A00FB1EC9 /* Benchmark */,
+				6C2E25F41C914A2D00500F93 /* TryParsecExperiment */,
+				6C2E268C1C91541500500F93 /* TryParsecExperimentTests */,
 				1FB5C1C21C829B790063B2EF /* TestAssets */,
 				1F92984F1BC3598300B68621 /* Frameworks */,
 				1FE8E4201B896E9100E1F2D0 /* Products */,
@@ -353,6 +434,8 @@
 				1FE8E4291B896E9100E1F2D0 /* TryParsecTests.xctest */,
 				1FA466C91C67F4B70089C8D9 /* TryParsecPerformanceTests.xctest */,
 				1FC182431C6AC14200FB1EC9 /* TryParsecBenchmark.app */,
+				6C2E25F31C914A2D00500F93 /* TryParsecExperiment.framework */,
+				6C2E25FC1C914A2D00500F93 /* TryParsecExperimentTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -417,6 +500,97 @@
 			name = "project xcconfigs";
 			sourceTree = "<group>";
 		};
+		6C2E25F41C914A2D00500F93 /* TryParsecExperiment */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E25F51C914A2D00500F93 /* TryParsecExperiment.h */,
+				6C2E26291C914C7E00500F93 /* Combinator.swift */,
+				6C2E262B1C914C7E00500F93 /* Parser+UnicodeScalarView.swift */,
+				6C2E262A1C914C7E00500F93 /* Result.swift */,
+				6C2E26411C914DD900500F93 /* Sepcialized+Prelude.swift */,
+				6C2E26351C914C9B00500F93 /* Basic */,
+				6C2E26501C914DEA00500F93 /* Arithmetic */,
+				6C2E26551C914E0D00500F93 /* JSON */,
+				6C2E25F71C914A2D00500F93 /* Info.plist */,
+			);
+			name = TryParsecExperiment;
+			path = Sources/TryParsecExperiment;
+			sourceTree = "<group>";
+		};
+		6C2E26351C914C9B00500F93 /* Basic */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E263F1C914DD900500F93 /* Operators.swift */,
+				6C2E26401C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift */,
+				6C2E26361C914CAE00500F93 /* Internals */,
+			);
+			name = Basic;
+			sourceTree = "<group>";
+		};
+		6C2E26361C914CAE00500F93 /* Internals */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E26471C914DE500500F93 /* Prelude.swift */,
+				6C2E26481C914DE500500F93 /* DoubleType.swift */,
+				6C2E26491C914DE500500F93 /* Optional+Helper.swift */,
+				6C2E264A1C914DE500500F93 /* Dictionary+Helper.swift */,
+			);
+			name = Internals;
+			sourceTree = "<group>";
+		};
+		6C2E26501C914DEA00500F93 /* Arithmetic */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E26521C914E0200500F93 /* Parser+Arithmetic.swift */,
+			);
+			name = Arithmetic;
+			sourceTree = "<group>";
+		};
+		6C2E26551C914E0D00500F93 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E26561C914E2300500F93 /* Parser+JSON.swift */,
+				6C2E26571C914E2300500F93 /* JSON.swift */,
+			);
+			name = JSON;
+			sourceTree = "<group>";
+		};
+		6C2E268C1C91541500500F93 /* TryParsecExperimentTests */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E26EC1C91577900500F93 /* PerformanceTests.swift */,
+				6C2E268D1C91544C00500F93 /* Helpers */,
+				6C2E26911C91544C00500F93 /* Specs */,
+			);
+			name = TryParsecExperimentTests;
+			path = excludedTests/TryParsecExperiment;
+			sourceTree = "<group>";
+		};
+		6C2E268D1C91544C00500F93 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E268E1C91544C00500F93 /* TestHelper.swift */,
+				6C2E268F1C91544C00500F93 /* TestModel.swift */,
+				6C2E26901C91544C00500F93 /* XCTestCase+Helper.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		6C2E26911C91544C00500F93 /* Specs */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E26951C91544C00500F93 /* HelperSpec.swift */,
+				6C2E26971C91544C00500F93 /* ParserSpec.swift */,
+				6C2E26931C91544C00500F93 /* CombinatorSpec.swift */,
+				6C2E26981C91544C00500F93 /* UnicodeScalarViewSpec.swift */,
+				6C2E26921C91544C00500F93 /* ArithmeticSpec.swift */,
+				6C2E26941C91544C00500F93 /* CSVSpec.swift */,
+				6C2E26961C91544C00500F93 /* JSONSpec.swift */,
+				6C2E26991C91544C00500F93 /* XMLSpec.swift */,
+			);
+			path = Specs;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -425,6 +599,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FE8E4231B896E9100E1F2D0 /* Parser.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25F01C914A2D00500F93 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E25F61C914A2D00500F93 /* TryParsecExperiment.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -504,6 +686,42 @@
 			productReference = 1FE8E4291B896E9100E1F2D0 /* TryParsecTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		6C2E25F21C914A2D00500F93 /* TryParsecExperiment */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6C2E26041C914A2E00500F93 /* Build configuration list for PBXNativeTarget "TryParsecExperiment" */;
+			buildPhases = (
+				6C2E25EE1C914A2D00500F93 /* Sources */,
+				6C2E25EF1C914A2D00500F93 /* Frameworks */,
+				6C2E25F01C914A2D00500F93 /* Headers */,
+				6C2E25F11C914A2D00500F93 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TryParsecExperiment;
+			productName = TryParsecExperiment;
+			productReference = 6C2E25F31C914A2D00500F93 /* TryParsecExperiment.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6C2E25FB1C914A2D00500F93 /* TryParsecExperimentTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6C2E26071C914A2E00500F93 /* Build configuration list for PBXNativeTarget "TryParsecExperimentTests" */;
+			buildPhases = (
+				6C2E25F81C914A2D00500F93 /* Sources */,
+				6C2E25F91C914A2D00500F93 /* Frameworks */,
+				6C2E25FA1C914A2D00500F93 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6C2E25FF1C914A2D00500F93 /* PBXTargetDependency */,
+			);
+			name = TryParsecExperimentTests;
+			productName = TryParsecExperimentTests;
+			productReference = 6C2E25FC1C914A2D00500F93 /* TryParsecExperimentTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -522,6 +740,12 @@
 					};
 					1FE8E4281B896E9100E1F2D0 = {
 						CreatedOnToolsVersion = 7.0;
+					};
+					6C2E25F21C914A2D00500F93 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
+					6C2E25FB1C914A2D00500F93 = {
+						CreatedOnToolsVersion = 7.2.1;
 					};
 				};
 			};
@@ -542,6 +766,8 @@
 				1FE8E4281B896E9100E1F2D0 /* TryParsecTests */,
 				1FA466A91C67F4B70089C8D9 /* TryParsecPerformanceTests */,
 				1FC182421C6AC14200FB1EC9 /* TryParsecBenchmark */,
+				6C2E25F21C914A2D00500F93 /* TryParsecExperiment */,
+				6C2E25FB1C914A2D00500F93 /* TryParsecExperimentTests */,
 			);
 		};
 /* End PBXProject section */
@@ -575,6 +801,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FB5C1C31C829B790063B2EF /* TestAssets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25F11C914A2D00500F93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25FA1C914A2D00500F93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E26641C914EF800500F93 /* TestAssets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -669,6 +910,35 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6C2E25EE1C914A2D00500F93 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E264C1C914DE500500F93 /* DoubleType.swift in Sources */,
+				6C2E26591C914E2300500F93 /* JSON.swift in Sources */,
+				6C2E262E1C914C7E00500F93 /* Parser+UnicodeScalarView.swift in Sources */,
+				6C2E26421C914DD900500F93 /* Operators.swift in Sources */,
+				6C2E264E1C914DE500500F93 /* Dictionary+Helper.swift in Sources */,
+				6C2E26531C914E0200500F93 /* Parser+Arithmetic.swift in Sources */,
+				6C2E262D1C914C7E00500F93 /* Result.swift in Sources */,
+				6C2E26441C914DD900500F93 /* Sepcialized+Prelude.swift in Sources */,
+				6C2E262C1C914C7E00500F93 /* Combinator.swift in Sources */,
+				6C2E26431C914DD900500F93 /* RangeReplaceableCollectionType+Helper.swift in Sources */,
+				6C2E264D1C914DE500500F93 /* Optional+Helper.swift in Sources */,
+				6C2E26581C914E2300500F93 /* Parser+JSON.swift in Sources */,
+				6C2E264B1C914DE500500F93 /* Prelude.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6C2E25F81C914A2D00500F93 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6C2E26EA1C91576800500F93 /* XCTestCase+Helper.swift in Sources */,
+				6C2E26ED1C91577900500F93 /* PerformanceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -686,6 +956,11 @@
 			isa = PBXTargetDependency;
 			target = 1FE8E41E1B896E9100E1F2D0 /* TryParsec */;
 			targetProxy = 1FE8E42B1B896E9100E1F2D0 /* PBXContainerItemProxy */;
+		};
+		6C2E25FF1C914A2D00500F93 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6C2E25F21C914A2D00500F93 /* TryParsecExperiment */;
+			targetProxy = 6C2E25FE1C914A2D00500F93 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -878,6 +1153,68 @@
 			};
 			name = Release;
 		};
+		6C2E26051C914A2E00500F93 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FF4206B1C4166EC00F69CBA /* UniversalFramework_Framework.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/TryParsecExperiment/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.norio-nomura.TryParsecExperiment";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		6C2E26061C914A2E00500F93 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FF4206B1C4166EC00F69CBA /* UniversalFramework_Framework.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/TryParsecExperiment/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.norio-nomura.TryParsecExperiment";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		6C2E26081C914A2E00500F93 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FF4206C1C4166EC00F69CBA /* UniversalFramework_Test.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.norio-nomura.TryParsecExperimentTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		6C2E26091C914A2E00500F93 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FF4206C1C4166EC00F69CBA /* UniversalFramework_Test.xcconfig */;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.norio-nomura.TryParsecExperimentTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -922,6 +1259,24 @@
 			buildConfigurations = (
 				1FE8E4371B896E9100E1F2D0 /* Debug */,
 				1FE8E4381B896E9100E1F2D0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6C2E26041C914A2E00500F93 /* Build configuration list for PBXNativeTarget "TryParsecExperiment" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C2E26051C914A2E00500F93 /* Debug */,
+				6C2E26061C914A2E00500F93 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6C2E26071C914A2E00500F93 /* Build configuration list for PBXNativeTarget "TryParsecExperimentTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C2E26081C914A2E00500F93 /* Debug */,
+				6C2E26091C914A2E00500F93 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TryParsec.xcodeproj/xcshareddata/xcschemes/TryParsecExperiment.xcscheme
+++ b/TryParsec.xcodeproj/xcshareddata/xcschemes/TryParsecExperiment.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6C2E25F21C914A2D00500F93"
+               BuildableName = "TryParsecExperiment.framework"
+               BlueprintName = "TryParsecExperiment"
+               ReferencedContainer = "container:TryParsec.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6C2E25FB1C914A2D00500F93"
+               BuildableName = "TryParsecExperimentTests.xctest"
+               BlueprintName = "TryParsecExperimentTests"
+               ReferencedContainer = "container:TryParsec.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6C2E25F21C914A2D00500F93"
+            BuildableName = "TryParsecExperiment.framework"
+            BlueprintName = "TryParsecExperiment"
+            ReferencedContainer = "container:TryParsec.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6C2E25F21C914A2D00500F93"
+            BuildableName = "TryParsecExperiment.framework"
+            BlueprintName = "TryParsecExperiment"
+            ReferencedContainer = "container:TryParsec.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6C2E25F21C914A2D00500F93"
+            BuildableName = "TryParsecExperiment.framework"
+            BlueprintName = "TryParsecExperiment"
+            ReferencedContainer = "container:TryParsec.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/excludedTests/TryParsecExperiment/Helpers/TestHelper.swift
+++ b/excludedTests/TryParsecExperiment/Helpers/TestHelper.swift
@@ -1,0 +1,26 @@
+import TryParsec
+
+extension Reply
+{
+    var _done: (input: In, output: Out)?
+    {
+        switch self {
+            case let .Done(input, output):
+                return (input, output)
+            default:
+                return nil
+        }
+    }
+
+    var _fail: (input: In, contexts: [String], message: String)?
+    {
+        switch self {
+            case let .Fail(input, contexts, message):
+                return (input, contexts, message)
+            default:
+                return nil
+        }
+    }
+}
+
+typealias USV = String.UnicodeScalarView

--- a/excludedTests/TryParsecExperiment/Helpers/TestHelper.swift
+++ b/excludedTests/TryParsecExperiment/Helpers/TestHelper.swift
@@ -1,6 +1,6 @@
-import TryParsec
+import TryParsecExperiment
 
-extension Reply
+extension Parser
 {
     var _done: (input: In, output: Out)?
     {

--- a/excludedTests/TryParsecExperiment/Helpers/TestModel.swift
+++ b/excludedTests/TryParsecExperiment/Helpers/TestModel.swift
@@ -1,0 +1,91 @@
+import TryParsec
+import Result
+import Curry
+
+struct _Model: FromJSON, ToJSON
+{
+    let string: String
+    let int: Int
+    let double: Double
+    let bool: Bool
+    let null: Bool?
+    let array: [Any]
+    let dict: [String : Any]
+
+    // Comment-Out: nested containers are not supported (requires HKT)
+//    let arrayOfArray: [[Any]]
+//    let dictOfDict: [String : [String : Any]]
+
+    let subModel: _SubModel
+    let dummy: Bool?    // dummy value not declared in JSON file
+
+    static func fromJSON(json: JSON) -> Result<_Model, JSON.ParseError>
+    {
+        return fromJSONObject(json) {
+            //
+            // NOTE:
+            // Too long applicative style writing causes compiler error:
+            // "Expression was too complex to be solved in reasonable time",
+            // so break them into smaller sub-expressions.
+            //
+            // See also: https://github.com/thoughtbot/Argo/issues/5
+            //
+            let r1 = curry(self.init)
+                <^> $0 !! "string"
+                <*> $0 !! "int"
+                <*> $0 !! "double"
+                <*> $0 !! "bool"
+                <*> $0 !! "null"
+
+            let r2 = r1
+                <*> $0 !! "array"
+                <*> $0 !! "dict"
+//                <*> $0 !! "arrayOfArray"
+//                <*> $0 !! "dictOfDict"
+
+            let r3 = r2
+                <*> $0 !! "subModel"
+                <*> $0 !? "dummy"
+
+            return r3
+        }
+    }
+
+    static func toJSON(model: _Model) -> JSON
+    {
+        return toJSONObject([
+            "string" ~ model.string,
+            "int" ~ model.int,
+            "double" ~ model.double,
+            "bool" ~ model.bool,
+            "null" ~ model.null,
+            "array" ~ model.array,
+            "dict" ~ model.dict,
+//            "arrayOfArray" ~ model.arrayOfArray,
+//            "dictOfDict" ~ model.dictOfDict,
+            "subModel" ~ model.subModel,
+//            "dummy" ~ model.dummy,    // Comment-Out: let's not generate dummy value
+        ])
+    }
+}
+
+struct _SubModel: FromJSON, ToJSON
+{
+    let string: String
+    // ...
+
+    static func fromJSON(json: JSON) -> Result<_SubModel, JSON.ParseError>
+    {
+        return fromJSONObject(json) {
+            curry(self.init)
+                <^> $0 !! "string"
+        }
+    }
+
+    static func toJSON(obj: _SubModel) -> JSON
+    {
+        return toJSONObject([
+            "string" ~ obj.string
+        ])
+    }
+}

--- a/excludedTests/TryParsecExperiment/Helpers/TestModel.swift
+++ b/excludedTests/TryParsecExperiment/Helpers/TestModel.swift
@@ -1,4 +1,4 @@
-import TryParsec
+import TryParsecExperiment
 import Result
 import Curry
 

--- a/excludedTests/TryParsecExperiment/Helpers/XCTestCase+Helper.swift
+++ b/excludedTests/TryParsecExperiment/Helpers/XCTestCase+Helper.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+extension XCTestCase
+{
+    public override func setUp()
+    {
+        super.setUp()
+        print("\n\n")
+    }
+
+    public override func tearDown()
+    {
+        print("\n\n")
+        super.tearDown()
+    }
+
+    class func loadString(resourceName: String, _ extensionName: String, filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__) -> String
+    {
+        let jsonString = NSBundle(forClass: self)
+            .URLForResource("TestAssets/\(resourceName)", withExtension: extensionName)
+            .flatMap { try? String(contentsOfURL: $0, encoding: NSUTF8StringEncoding) }
+
+        if jsonString == nil {
+            XCTFail("\(functionName): No file (\(resourceName).\(extensionName)) found.")
+        }
+
+        return jsonString!
+    }
+}

--- a/excludedTests/TryParsecExperiment/PerformanceTests.swift
+++ b/excludedTests/TryParsecExperiment/PerformanceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import TryParsecExperiment
 
 private var _testString = ""
-private let _loops = 100
+private let _loops = 1000
 
 class ParsecTests: XCTestCase {
     

--- a/excludedTests/TryParsecExperiment/PerformanceTests.swift
+++ b/excludedTests/TryParsecExperiment/PerformanceTests.swift
@@ -7,7 +7,7 @@ private let _loops = 1000
 class ParsecTests: XCTestCase {
     
     func testExample() {
-        let r = parseArithmetic("1")
+        let r = parseArithmetic("1").value!
         XCTAssertEqual(r, 1)
     }
 

--- a/excludedTests/TryParsecExperiment/PerformanceTests.swift
+++ b/excludedTests/TryParsecExperiment/PerformanceTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import TryParsecExperiment
+
+private var _testString = ""
+private let _loops = 100
+
+class ParsecTests: XCTestCase {
+    
+    func testExample() {
+        let r = parseArithmetic("1")
+        XCTAssertEqual(r, 1)
+    }
+
+    override class func setUp() {
+        _testString = self.loadString("test4", "json")
+    }
+
+    func testPerformance_TryParsecExperiment() {
+        self.measureBlock {
+            for _ in 1..._loops {
+                let _ = parseJSON(_testString)
+            }
+        }
+    }
+
+    func testPerformance_NSJSONSerialization() {
+        self.measureBlock {
+            for _ in 1..._loops {
+                let jsonData = _testString.dataUsingEncoding(NSUTF8StringEncoding)!
+                let _ = (try? NSJSONSerialization.JSONObjectWithData(jsonData, options: .AllowFragments)) as? NSDictionary
+            }
+        }
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/ArithmeticSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/ArithmeticSpec.swift
@@ -1,4 +1,4 @@
-import TryParsec
+import TryParsecExperiment
 import Quick
 import Nimble
 

--- a/excludedTests/TryParsecExperiment/Specs/ArithmeticSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/ArithmeticSpec.swift
@@ -1,0 +1,67 @@
+import TryParsec
+import Quick
+import Nimble
+
+class ArithmeticSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("parseArithmetic") {
+
+            it("`1` = 1") {
+                let r = parseArithmetic("1")
+                expect(r.value) == 1
+            }
+
+            it("`1+2` = 3") {
+                let r = parseArithmetic("1+2")
+                expect(r.value) == 3
+            }
+
+            it("`1-2` = -1") {
+                let r = parseArithmetic("1-2")
+                expect(r.value) == -1
+            }
+
+            it("`2*3` = 6") {
+                let r = parseArithmetic("2*3")
+                expect(r.value) == 6
+            }
+
+            it("`2/3` = 0  (float not supported)") {
+                let r = parseArithmetic("2/3")
+                expect(r.value) == 0
+            }
+
+            it("`1-2-3` = -4  (left-associative)") {
+                let r = parseArithmetic("1-2-3")
+                expect(r.value) == -4
+            }
+
+            it("`1/2*2` = 0  (`1/2` will be zero)") {
+                let r = parseArithmetic("1/2*2")
+                expect(r.value) == 0
+            }
+
+            it("`(1+2)*3` = 9") {
+                let r = parseArithmetic("(1+2)*3")
+                expect(r.value) == 9
+            }
+
+            it("` ( 12 + 3 )         * 4+5` = 65") {
+                let r = parseArithmetic(" ( 12 + 3 )         * 4+5")
+                expect(r.value) == 65
+            }
+        }
+
+        describe("Not Supported") {
+
+            it("`1.2` fails (float is not supported yet)") {
+                let r = parseArithmetic("1.2")
+                expect(r.value).to(beNil())
+                expect(r.error).notTo(beNil())
+            }
+
+        }
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/CSVSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/CSVSpec.swift
@@ -1,4 +1,4 @@
-import TryParsec
+import TryParsecExperiment
 import Quick
 import Nimble
 

--- a/excludedTests/TryParsecExperiment/Specs/CSVSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/CSVSpec.swift
@@ -1,0 +1,47 @@
+import TryParsec
+import Quick
+import Nimble
+
+class CSVSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("parseCSV") {
+
+            it("succeeds (\\r\\n)") {
+                let r = parseCSV("foo,bar,baz\r\n1,22,333\r\n")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+            it("succeeds (\\n)") {
+                let r = parseCSV("foo,bar,baz\n1,22,333\n")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+            it("succeeds (\\n + no end break)") {
+                let r = parseCSV("foo,bar,baz\n1,22,333")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+        }
+
+        describe("parseCSV (separator = \t)") {
+
+            it("succeeds (\\r\\n)") {
+                let r = parseCSV(separator: "\t", "foo\tbar\tbaz\r\n1\t22\t333\r\n")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+            it("succeeds (\\n)") {
+                let r = parseCSV(separator: "\t", "foo\tbar\tbaz\n1\t22\t333\n")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+            it("succeeds (\\n + no end break)") {
+                let r = parseCSV(separator: "\t", "foo\tbar\tbaz\n1\t22\t333")
+                expect(r.value) == [ ["foo", "bar", "baz"], ["1", "22", "333"] ]
+            }
+
+        }
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/CombinatorSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/CombinatorSpec.swift
@@ -1,0 +1,410 @@
+import TryParsec
+import Quick
+import Nimble
+
+class CombinatorSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("many") {
+
+            let p: Parser<USV, USV> = many(digit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "123"
+            }
+
+            it("succeeds (zero digit)") {
+                let r = parse(p, "abcdef")._done
+                expect(r?.input) == "abcdef"
+                expect(r?.output) == ""
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ""
+            }
+
+        }
+
+        describe("many1") {
+
+            let p: Parser<USV, USV> = many1(digit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "123"
+            }
+
+            it("fails") {
+                let r = parse(p, "abcdef")._fail
+                expect(r?.input) == "abcdef"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("manyTill") {
+
+            let p: Parser<USV, USV> = manyTill(any, string("="))
+
+            it("succeeds") {
+                let r = parse(p, "123=abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "123"
+            }
+
+            it("fails") {
+                let r = parse(p, "123abc")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("skipMany") {
+
+            let p: Parser<USV, ()> = skipMany(digit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (zero occurrence)") {
+                let r = parse(p, "abcdef")._done
+                expect(r?.input) == "abcdef"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+        }
+
+        describe("skipMany1") {
+
+            let p: Parser<USV, ()> = skipMany1(digit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == ()
+            }
+
+            it("fails (zero occurrence)") {
+                let r = parse(p, "abcdef")._fail
+                expect(r?.input) == "abcdef"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("sepBy") {
+
+            let p: Parser<USV, [UnicodeScalar]> = sepBy(digit, char(","))
+
+            it("succeeds") {
+                let r = parse(p, "1,2,3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (tail-comma is NOT CONSUMED)") {
+                let r = parse(p, "1,2,3,")._done
+                expect(r?.input) == ","
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (zero occurrence of digit-then-comma)") {
+                let r = parse(p, ",1,2,3")._done
+                expect(r?.input) == ",1,2,3"
+                expect(r?.output) == []
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == []
+            }
+
+        }
+
+        describe("sepBy1") {
+
+            let p: Parser<USV, [UnicodeScalar]> = sepBy1(digit, char(","))
+
+            it("succeeds") {
+                let r = parse(p, "1,2,3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (tail-comma is NOT CONSUMED)") {
+                let r = parse(p, "1,2,3,")._done
+                expect(r?.input) == ","
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("fails (zero occurrence of digit-then-comma)") {
+                let r = parse(p, ",1,2,3")._fail
+                expect(r?.input) == ",1,2,3"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("sepEndBy") {
+
+            let p: Parser<USV, [UnicodeScalar]> = sepEndBy(digit, char(","))
+
+            it("succeeds") {
+                let r = parse(p, "1,2,3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (tail-comma IS CONSUMED)") {
+                let r = parse(p, "1,2,3,")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (zero occurrence of digit-then-comma)") {
+                let r = parse(p, ",1,2,3")._done
+                expect(r?.input) == ",1,2,3"
+                expect(r?.output) == []
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == []
+            }
+
+        }
+
+        describe("sepEndBy1") {
+
+            let p: Parser<USV, [UnicodeScalar]> = sepEndBy1(digit, char(","))
+
+            it("succeeds") {
+                let r = parse(p, "1,2,3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("succeeds (tail-comma IS CONSUMED)") {
+                let r = parse(p, "1,2,3,")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ["1", "2", "3"]
+            }
+
+            it("fails (zero occurrence of digit-then-comma)") {
+                let r = parse(p, ",1,2,3")._fail
+                expect(r?.input) == ",1,2,3"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("count") {
+
+            let p: Parser<USV, [USV]> = count(3, string("123"))
+
+            it("succeeds") {
+                let r = parse(p, "123123123123")._done
+                expect(r?.input) == "123"
+                expect(r?.output) == ["123", "123", "123"]
+            }
+
+            it("fails") {
+                let r = parse(p, "123123xyz123")._fail
+                expect(r?.input) == "xyz123"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("chainl") {
+
+            let p: Parser<USV, Double> = chainl(number, char("-") *> pure(-), 999)
+
+            it("succeeds (left-association)") {
+                let r = parse(p, "1-2-3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == -4
+            }
+
+            it("succeeds (zero occurrence)") {
+                let r = parse(p, "=1-2-3")._done
+                expect(r?.input) == "=1-2-3"
+                expect(r?.output) == 999
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 999            }
+
+        }
+
+        describe("chainl1") {
+
+            let p: Parser<USV, Double> = chainl1(number, char("-") *> pure(-))
+
+            it("succeeds (left-association)") {
+                let r = parse(p, "1-2-3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == -4
+            }
+
+            it("fails (zero occurrence)") {
+                let r = parse(p, "=1-2-3")._fail
+                expect(r?.input) == "=1-2-3"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("chainr") {
+
+            let p: Parser<USV, Double> = chainr(number, char("-") *> pure(-), 999)
+
+            it("succeeds (right-association)") {
+                let r = parse(p, "1-2-3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 2
+            }
+
+            it("succeeds (zero occurrence)") {
+                let r = parse(p, "=1-2-3")._done
+                expect(r?.input) == "=1-2-3"
+                expect(r?.output) == 999
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 999            }
+
+        }
+
+        describe("chainr1") {
+
+            let p: Parser<USV, Double> = chainr1(number, char("-") *> pure(-))
+
+            it("succeeds (right-association)") {
+                let r = parse(p, "1-2-3")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 2
+            }
+
+            it("fails (zero occurrence)") {
+                let r = parse(p, "=1-2-3")._fail
+                expect(r?.input) == "=1-2-3"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("lookAhead") {
+
+            let p: Parser<USV, UnicodeScalar> = lookAhead(any)
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/CombinatorSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/CombinatorSpec.swift
@@ -1,4 +1,4 @@
-import TryParsec
+import TryParsecExperiment
 import Quick
 import Nimble
 
@@ -8,7 +8,7 @@ class CombinatorSpec: QuickSpec
     {
         describe("many") {
 
-            let p: Parser<USV, USV> = many(digit)
+            let p: Parser<StringContainer>.Function = many(digit)
 
             it("succeeds") {
                 let r = parse(p, "123abc")._done
@@ -32,7 +32,7 @@ class CombinatorSpec: QuickSpec
 
         describe("many1") {
 
-            let p: Parser<USV, USV> = many1(digit)
+            let p: Parser<StringContainer>.Function = many1(digit)
 
             it("succeeds") {
                 let r = parse(p, "123abc")._done
@@ -58,7 +58,7 @@ class CombinatorSpec: QuickSpec
 
         describe("manyTill") {
 
-            let p: Parser<USV, USV> = manyTill(any, string("="))
+            let p: Parser<StringContainer>.Function = manyTill(any, string("="))
 
             it("succeeds") {
                 let r = parse(p, "123=abc")._done
@@ -84,7 +84,7 @@ class CombinatorSpec: QuickSpec
 
         describe("skipMany") {
 
-            let p: Parser<USV, ()> = skipMany(digit)
+            let p: Parser<()>.Function = skipMany(digit)
 
             it("succeeds") {
                 let r = parse(p, "123abc")._done
@@ -108,7 +108,7 @@ class CombinatorSpec: QuickSpec
 
         describe("skipMany1") {
 
-            let p: Parser<USV, ()> = skipMany1(digit)
+            let p: Parser<()>.Function = skipMany1(digit)
 
             it("succeeds") {
                 let r = parse(p, "123abc")._done
@@ -134,7 +134,7 @@ class CombinatorSpec: QuickSpec
 
         describe("sepBy") {
 
-            let p: Parser<USV, [UnicodeScalar]> = sepBy(digit, char(","))
+            let p: Parser<[StringElement]>.Function = sepBy(digit, char(","))
 
             it("succeeds") {
                 let r = parse(p, "1,2,3")._done
@@ -164,7 +164,7 @@ class CombinatorSpec: QuickSpec
 
         describe("sepBy1") {
 
-            let p: Parser<USV, [UnicodeScalar]> = sepBy1(digit, char(","))
+            let p: Parser<[StringElement]>.Function = sepBy1(digit, char(","))
 
             it("succeeds") {
                 let r = parse(p, "1,2,3")._done
@@ -196,7 +196,7 @@ class CombinatorSpec: QuickSpec
 
         describe("sepEndBy") {
 
-            let p: Parser<USV, [UnicodeScalar]> = sepEndBy(digit, char(","))
+            let p: Parser<[StringElement]>.Function = sepEndBy(digit, char(","))
 
             it("succeeds") {
                 let r = parse(p, "1,2,3")._done
@@ -226,7 +226,7 @@ class CombinatorSpec: QuickSpec
 
         describe("sepEndBy1") {
 
-            let p: Parser<USV, [UnicodeScalar]> = sepEndBy1(digit, char(","))
+            let p: Parser<[StringElement]>.Function = sepEndBy1(digit, char(","))
 
             it("succeeds") {
                 let r = parse(p, "1,2,3")._done
@@ -258,7 +258,7 @@ class CombinatorSpec: QuickSpec
 
         describe("count") {
 
-            let p: Parser<USV, [USV]> = count(3, string("123"))
+            let p: Parser<[StringContainer]>.Function = count(3, string("123"))
 
             it("succeeds") {
                 let r = parse(p, "123123123123")._done
@@ -284,7 +284,7 @@ class CombinatorSpec: QuickSpec
 
         describe("chainl") {
 
-            let p: Parser<USV, Double> = chainl(number, char("-") *> pure(-), 999)
+            let p: Parser<Double>.Function = chainl(number, char("-") *> { pure(-) }, 999)
 
             it("succeeds (left-association)") {
                 let r = parse(p, "1-2-3")._done
@@ -307,7 +307,7 @@ class CombinatorSpec: QuickSpec
 
         describe("chainl1") {
 
-            let p: Parser<USV, Double> = chainl1(number, char("-") *> pure(-))
+            let p: Parser<Double>.Function = chainl1(number, char("-") *> { pure(-) })
 
             it("succeeds (left-association)") {
                 let r = parse(p, "1-2-3")._done
@@ -333,7 +333,7 @@ class CombinatorSpec: QuickSpec
 
         describe("chainr") {
 
-            let p: Parser<USV, Double> = chainr(number, char("-") *> pure(-), 999)
+            let p: Parser<Double>.Function = chainr(number, char("-") *> { pure(-) }, 999)
 
             it("succeeds (right-association)") {
                 let r = parse(p, "1-2-3")._done
@@ -356,7 +356,7 @@ class CombinatorSpec: QuickSpec
 
         describe("chainr1") {
 
-            let p: Parser<USV, Double> = chainr1(number, char("-") *> pure(-))
+            let p: Parser<Double>.Function = chainr1(number, char("-") *> { pure(-) })
 
             it("succeeds (right-association)") {
                 let r = parse(p, "1-2-3")._done
@@ -382,7 +382,7 @@ class CombinatorSpec: QuickSpec
 
         describe("lookAhead") {
 
-            let p: Parser<USV, UnicodeScalar> = lookAhead(any)
+            let p: Parser<StringElement>.Function = lookAhead(any)
 
             it("succeeds") {
                 let r = parse(p, "abc")._done

--- a/excludedTests/TryParsecExperiment/Specs/HelperSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/HelperSpec.swift
@@ -1,0 +1,61 @@
+@testable import TryParsec
+import Result
+import Quick
+import Nimble
+
+class HelperSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("splitAt") {
+
+            it("splitAt(1)") {
+                let (heads, tails) = splitAt(1)("abc" as USV)
+                expect(heads) == ["a"]
+                expect(tails) == ["b", "c"]
+            }
+
+            it("splitAt(0)") {
+                let (heads, tails) = splitAt(0)("abc" as USV)
+                expect(heads) == []
+                expect(tails) == ["a", "b", "c"]
+            }
+
+            it("splitAt(999)") {
+                let (heads, tails) = splitAt(999)("abc" as USV)
+                expect(heads) == ["a", "b", "c"]
+                expect(tails) == []
+            }
+
+            it("splitAt(0)(\"\")") {
+                let (heads, tails) = splitAt(0)("" as USV)
+                expect(heads) == []
+                expect(tails) == []
+            }
+
+        }
+
+        describe("trim") {
+
+            it("trims head & tail whitespaces") {
+                let trimmed = trim("   Trim me!   ")
+                expect(trimmed) == "Trim me!"
+            }
+
+            it("doesn't trim middle whitespaces") {
+                let trimmed = trim("Dooooon't    trrrrrim     meeeee!")
+                expect(trimmed) == "Dooooon't    trrrrrim     meeeee!"
+            }
+
+        }
+
+        describe("RangeReplaceableCollectionType (RRC)") {
+
+            it("any RRC e.g. `ArraySlice` can initialize with SequenceType") {
+                let arr = ArraySlice<UnicodeScalar>("abc" as USV)
+                expect(Array(arr)) == Array(["a", "b", "c"])
+            }
+
+        }
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/HelperSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/HelperSpec.swift
@@ -1,4 +1,4 @@
-@testable import TryParsec
+@testable import TryParsecExperiment
 import Result
 import Quick
 import Nimble

--- a/excludedTests/TryParsecExperiment/Specs/JSONSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/JSONSpec.swift
@@ -1,0 +1,238 @@
+@testable import TryParsec
+import Result
+import Quick
+import Nimble
+
+class JSONSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("parseJSON") {
+
+            it("succeeds") {
+
+                let jsonString = "{ \"items\": [ { \"hidden\" : true } ] }"
+
+                let expected = JSON.Object([
+                    "items" : JSON.Array([
+                        JSON.Object([
+                            "hidden" : JSON.Bool(true)
+                        ])
+                    ])
+                ])
+
+                let r = parseJSON(jsonString)
+                expect(r.value) == expected
+
+                expect(r.value?["items"]?[0]?["hidden"]?.rawBool) == true
+
+            }
+
+            it("succeeds") {
+
+                let jsonString = "{ \"string\" : \"hello\", \"array\" : [1, \"two\", [true, null]] }"
+
+                let expected = JSON.Object([
+                    "string" : .String("hello"),
+                    "array" : .Array([.Number(1), .String("two"), .Array([.Bool(true), .Null])])
+                ])
+
+                let r = parseJSON(jsonString)
+                expect(r.value) == expected
+
+                expect(r.value?["string"]?.rawString) == "hello"
+                expect(r.value?["array"]?[0]?.rawNumber) == 1
+                expect(r.value?["array"]?[1]?.rawString) == "two"
+                expect(r.value?["array"]?[2]?[0]?.rawBool) == true
+                expect(r.value?["array"]?[2]?[1]?.rawNull) == ()
+
+            }
+
+        }
+
+        describe("JSON (internal)") {
+
+            describe("jsonString") {
+
+                let p = jsonString
+
+                it("succeeds") {
+                    let r = parse(p, "\"123\"")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.String("123")
+                }
+
+                it("succeeds (partial)") {
+                    let r = parse(p, "\"123\nabc\"other")._done
+                    expect(r?.input) == "other"
+                    expect(r?.output) == JSON.String("123\nabc")
+                }
+
+                it("fails") {
+                    let r = parse(p, "null")._fail
+                    expect(r?.input) == "null"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+            describe("jsonNumber") {
+
+                let p = jsonNumber
+
+                it("succeeds") {
+                    let r = parse(p, "1.2")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Number(1.2)
+                }
+
+                it("succeeds (scientific small-e)") {
+                    let r = parse(p, "1.2e3")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Number(1200)
+                }
+
+                it("succeeds (scientific large-E)") {
+                    let r = parse(p, "-1.2E3")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Number(-1200)
+                }
+
+                it("fails") {
+                    let r = parse(p, "null")._fail
+                    expect(r?.input) == "null"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+            describe("jsonBool") {
+
+                let p = jsonBool
+
+                it("succeeds (true)") {
+                    let r = parse(p, "true")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Bool(true)
+                }
+
+                it("succeeds (false)") {
+                    let r = parse(p, "false")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Bool(false)
+                }
+
+                it("fails") {
+                    let r = parse(p, "null")._fail
+                    expect(r?.input) == "null"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+                it("fails (capital letter)") {
+                    let r = parse(p, "True")._fail
+                    expect(r?.input) == "True"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+            describe("jsonArray") {
+
+                let p = jsonArray
+
+                it("succeeds") {
+                    let r = parse(p, "[ true, false ]")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Array([JSON.Bool(true), JSON.Bool(false)])
+                }
+
+                it("fails") {
+                    let r = parse(p, "null")._fail
+                    expect(r?.input) == "null"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+            describe("jsonObject") {
+
+                let p = jsonObject
+
+                it("succeeds") {
+                    let r = parse(p, "{ \"test\" : true }")._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == JSON.Object([ "test" : JSON.Bool(true) ])
+                }
+
+                it("fails") {
+                    let r = parse(p, "null")._fail
+                    expect(r?.input) == "null"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+        }
+
+        describe("JSON decode") {
+
+            it("decodes as array") {
+                let str = "[1, 2, 3]"
+                let r: Result<[Double], JSON.ParseError> = decode(str)
+                expect(r.value) == [ 1, 2, 3 ]
+            }
+
+            it("decodes as object") {
+                let str = "{ \"value\": 5 }"
+                let r: Result<[String : Double], JSON.ParseError> = decode(str)
+                expect(r.value) == [ "value" : 5 ]
+            }
+
+        }
+
+        describe("JSON Files") {
+
+            beforeEach {
+                print("------------------------------")
+            }
+
+            it("parses JSON files") {
+                let files = [ "test1", "test2", "test3", "test4", "test5", "escape" ]
+
+                for file in files {
+                    print("file = \(file)")
+                    print("")
+
+                    let jsonString = self.dynamicType.loadString(file, "json")
+                    print("jsonString = ", jsonString)
+                    print("")
+
+                    let jsonAST = parseJSON(jsonString)
+                    expect(jsonAST.value).toNot(beNil())
+                    print("jsonAST = ", jsonAST)
+                    print("")
+                }
+            }
+
+            it("decodes JSON file as _Model & encode") {
+                let jsonString = self.dynamicType.loadString("basic", "json")
+                print("jsonString =", jsonString)
+
+                let decoded: Result<_Model, JSON.ParseError> = decode(jsonString)
+                expect(decoded.value).toNot(beNil())
+                print("decoded =", decoded)
+
+                let encoded = encode(decoded.value!)
+                print("encoded =", encoded)
+            }
+
+        }
+
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/JSONSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/JSONSpec.swift
@@ -1,4 +1,4 @@
-@testable import TryParsec
+@testable import TryParsecExperiment
 import Result
 import Quick
 import Nimble
@@ -220,17 +220,17 @@ class JSONSpec: QuickSpec
                 }
             }
 
-            it("decodes JSON file as _Model & encode") {
-                let jsonString = self.dynamicType.loadString("basic", "json")
-                print("jsonString =", jsonString)
-
-                let decoded: Result<_Model, JSON.ParseError> = decode(jsonString)
-                expect(decoded.value).toNot(beNil())
-                print("decoded =", decoded)
-
-                let encoded = encode(decoded.value!)
-                print("encoded =", encoded)
-            }
+//            it("decodes JSON file as _Model & encode") {
+//                let jsonString = self.dynamicType.loadString("basic", "json")
+//                print("jsonString =", jsonString)
+//
+//                let decoded: Result<_Model, JSON.ParseError> = decode(jsonString)
+//                expect(decoded.value).toNot(beNil())
+//                print("decoded =", decoded)
+//
+//                let encoded = encode(decoded.value!)
+//                print("encoded =", encoded)
+//            }
 
         }
 

--- a/excludedTests/TryParsecExperiment/Specs/ParserSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/ParserSpec.swift
@@ -1,0 +1,261 @@
+import TryParsec
+import Quick
+import Nimble
+
+class ParserSpec: QuickSpec
+{
+    override func spec()
+    {
+        // MARK: Functor
+
+        describe("Functor") {
+
+            describe("`<^>` (fmap)") {
+
+                it("`f <^> p` succeeds when `p` succeeds") {
+                    let p: Parser<String, Int> = { $0 + 1 } <^> pure(1)
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "hello"
+                    expect(r?.output) == 2
+                }
+
+                it("`f <^> p` fails when `p` fails") {
+                    let p: Parser<String, Int> = { $0 + 1 } <^> fail("oops")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "oops"
+                }
+
+            }
+
+            describe("`<&>` (flip fmap)") {
+
+                it("`p <&> f` succeeds when `p` succeeds") {
+                    let p: Parser<String, Int> = pure(1) <&> { $0 + 1 }
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "hello"
+                    expect(r?.output) == 2
+                }
+
+                it("`p <&> f` fails when `p` fails") {
+                    let p: Parser<String, Int> = fail("oops") <&> { $0 + 1 }
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "oops"
+                }
+
+            }
+
+        }
+
+        // MARK: Applicative
+
+        describe("Applicative") {
+
+            describe("`<*>` (ap)") {
+
+                it("`f <*> p` succeeds when both `f` and `p` succeed") {
+                    let p: Parser<String, Int> = pure({ $0 + 1 }) <*> pure(1)
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "hello"
+                    expect(r?.output) == 2
+                }
+
+                it("`f <*> p` fails when `f` succeeds but `p` fails") {
+                    let p: Parser<String, Int> = pure({ $0 + 1 }) <*> fail("oops")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "oops"
+                }
+
+                it("`f <*> p` fails when `f` fails") {
+                    let p: Parser<String, Int> = fail("oops") <*> pure(1)
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "oops"
+                }
+
+                it("`f <^> p1 <*> p2` (applicative style) succeeds when `f`, `p1`, and `p2` succeed") {
+                    let p = { a in { b in (a, b) } } <^> char("h") <*> char("e")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "llo"
+                    expect(r?.output.0) == "h"
+                    expect(r?.output.1) == "e"
+                }
+
+            }
+
+            describe("`*>` (sequence, discarding left)") {
+
+                it("`p *> q` succeeds when both `p` and `q` succeed") {
+                    let p = char("h") *> char("e")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "llo"
+                    expect(r?.output) == "e"
+                }
+
+                it("`p *> q` fails when `p` succeeds but `q` fails") {
+                    let p = char("h") *> char("x")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "ello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+                it("`p *> q` fails when `p` fails") {
+                    let p = char("x") *> char("h")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+            describe("`<*` (sequence, discarding right)") {
+
+                it("`p <* q` succeeds when both `p` and `q` succeed") {
+                    let p = char("h") <* char("e")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "llo"
+                    expect(r?.output) == "h"
+                }
+
+                it("`p <* q` fails when `p` succeeds but `q` fails") {
+                    let p = char("h") <* char("x")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "ello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+                it("`p <* q` fails when `p` fails") {
+                    let p = char("x") <* char("h")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+        }
+
+        // MARK: Alternative
+
+        describe("Alternative") {
+
+            describe("`<|>` (choice, alternation)") {
+
+                it("`p <|> q` succeeds when both `p` and `q` succeed") {
+                    let p = string("he") <|> string("hell")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "llo"
+                    expect(r?.output) == "he"
+                }
+
+                it("`p <|> q` succeeds when `p` succeeds but `q` fails") {
+                    let p = string("hell") <|> string("x")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "o"
+                    expect(r?.output) == "hell"
+                }
+
+                it("`p <|> q` succeeds when `p` fails but `q` succeeds") {
+                    let p = string("x") <|> string("hell")
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "o"
+                    expect(r?.output) == "hell"
+                }
+
+                it("`p <|> q` fails when both `p` and `q` fail") {
+                    let p = string("x") <|> string("y")
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+        }
+
+        // MARK: Monad
+
+        describe("Monad") {
+
+            describe(">>- (bind, flatMap)") {
+
+                it("`p >>- f` succeeds when both `p` and `f()` succeeds") {
+                    let p = string("he") >>- { pure($0 + ["y"]) }
+                    let r = parse(p, "hello")._done
+                    expect(r?.input) == "llo"
+                    expect(r?.output) == "hey"
+                }
+
+                it("`p >>- f` fails when `p` succeeds but `f()` fails") {
+                    let p: Parser<USV, USV> = string("he") >>- { _ in fail("oops") }
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "llo"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "oops"
+                }
+
+                it("`p >>- f` fails when `p` fails") {
+                    let p: Parser<USV, USV> = string("x") >>- { _ in pure("I made it!!!") }
+                    let r = parse(p, "hello")._fail
+                    expect(r?.input) == "hello"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+            }
+
+        }
+
+        // MARK: Peek
+
+        describe("peek") {
+
+            let p: Parser<USV, UnicodeScalar> = peek()
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "peek"
+            }
+
+        }
+
+        describe("endOfInput") {
+
+            let p: Parser<USV, ()> = endOfInput()
+
+            it("succeeds") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+            it("fails") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "endOfInput"
+            }
+
+        }
+
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/UnicodeScalarViewSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/UnicodeScalarViewSpec.swift
@@ -1,0 +1,627 @@
+import TryParsec
+import Quick
+import Nimble
+
+class UnicodeScalarViewSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("satisfy") {
+
+            let p = satisfy { $0 == "1" }
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "23abc"
+                expect(r?.output) == "1"
+            }
+
+            it("fails") {
+                let r = parse(p, "abcdef")._fail
+                expect(r?.input) == "abcdef"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("skip") {
+
+            let p = skip { $0 == "1" }
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "23abc"
+                expect(r?.output) == ()
+            }
+
+            it("fails") {
+                let r = parse(p, "abcdef")._fail
+                expect(r?.input) == "abcdef"
+                expect(r?.contexts) == []
+                expect(r?.message) == "skip"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "skip"
+            }
+
+        }
+
+        describe("skipWhile") {
+
+            let p = skipWhile(isDigit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (zero occurrence)") {
+                let r = parse(p, "abcdef")._done
+                expect(r?.input) == "abcdef"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+        }
+
+        describe("take") {
+
+            let p = take(3)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "123"
+            }
+
+            it("fails (input is too short)") {
+                let r = parse(p, "12")._fail
+                expect(r?.input) == "12"
+                expect(r?.contexts) == []
+                expect(r?.message) == "take(3)"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "take(3)"
+            }
+
+        }
+
+        describe("takeWhile") {
+
+            let p = takeWhile(isDigit)
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "123"
+            }
+
+            it("succeeds (zero occurrence)") {
+                let r = parse(p, "abcdef")._done
+                expect(r?.input) == "abcdef"
+                expect(r?.output) == ""
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ""
+            }
+
+        }
+
+        describe("any") {
+
+            let p = any
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "23abc"
+                expect(r?.output) == "1"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("not") {
+
+            let p = not("a")
+
+            it("succeeds") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == "23abc"
+                expect(r?.output) == "1"
+            }
+
+            it("fails") {
+                let r = parse(p, "abcdef")._fail
+                expect(r?.input) == "abcdef"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("oneOf") {
+
+            let p = oneOf("123") // same as `oneOf(["1", "2", "3"])`
+
+            it("succeeds") {
+                let r = parse(p, "1abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "1"
+            }
+
+            it("fails") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("noneOf") {
+
+            let p = noneOf("123") // same as `oneOf(["1", "2", "3"])`
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "bc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "1abc")._fail
+                expect(r?.input) == "1abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("digit") {
+
+            let p = digit
+
+            it("succeeds") {
+                let r = parse(p, "123")._done
+                expect(r?.input) == "23"
+                expect(r?.output) == "1"
+            }
+
+            it("fails") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("lowerAlphabet") {
+
+            let p = lowerAlphabet
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "bc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "ABC")._fail
+                expect(r?.input) == "ABC"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("upperAlphabet") {
+
+            let p = upperAlphabet
+
+            it("succeeds") {
+                let r = parse(p, "ABC")._done
+                expect(r?.input) == "BC"
+                expect(r?.output) == "A"
+            }
+
+            it("fails") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("alphabet") {
+
+            let p = alphabet
+
+            it("succeeds (uppercase)") {
+                let r = parse(p, "ABC")._done
+                expect(r?.input) == "BC"
+                expect(r?.output) == "A"
+            }
+
+            it("succeeds (lowercase)") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "bc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "123")._fail
+                expect(r?.input) == "123"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("alphaNum") {
+
+            let p = alphaNum
+
+            it("succeeds (uppercase)") {
+                let r = parse(p, "ABC")._done
+                expect(r?.input) == "BC"
+                expect(r?.output) == "A"
+            }
+
+            it("succeeds (lowercase)") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "bc"
+                expect(r?.output) == "a"
+            }
+
+            it("succeeds (numeric)") {
+                let r = parse(p, "123")._done
+                expect(r?.input) == "23"
+                expect(r?.output) == "1"
+            }
+
+            it("fails") {
+                let r = parse(p, "!@#")._fail
+                expect(r?.input) == "!@#"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("space") {
+
+            let p = space
+
+            it("succeeds (space)") {
+                let r = parse(p, " abc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == " "
+            }
+
+            it("succeeds (\\t)") {
+                let r = parse(p, "\tabc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "\t"
+            }
+
+            it("succeeds (\\n)") {
+                let r = parse(p, "\nabc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "\n"
+            }
+
+            it("succeeds (\\r)") {
+                let r = parse(p, "\rabc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == "\r"
+            }
+
+            it("fails (no spaces)") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("skipSpaces") {
+
+            let p = skipSpaces
+
+            it("succeeds") {
+                let r = parse(p, " \t\n\rabc")._done
+                expect(r?.input) == "abc"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (no spaces)") {
+                let r = parse(p, "123")._done
+                expect(r?.input) == "123"
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+        }
+
+        describe("char") {
+
+            let p = char("a")
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "bc"
+                expect(r?.output) == "a"
+            }
+
+            it("fails") {
+                let r = parse(p, "1abc")._fail
+                expect(r?.input) == "1abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("string") {
+
+            let p = string("ab")
+
+            it("succeeds") {
+                let r = parse(p, "abc")._done
+                expect(r?.input) == "c"
+                expect(r?.output) == "ab"
+            }
+
+            it("fails") {
+                let r = parse(p, "1abc")._fail
+                expect(r?.input) == "1abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("asciiCI") {
+
+            let p = asciiCI("ab")
+
+            it("succeeds") {
+                let r = parse(p, "aBc")._done
+                expect(r?.input) == "c"
+                expect(r?.output) == "aB"
+            }
+
+            it("fails") {
+                let r = parse(p, "1aBc")._fail
+                expect(r?.input) == "1aBc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "_string"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "_string"
+            }
+
+        }
+
+        describe("number") {
+
+            let p = number
+
+            it("succeeds") {
+                let r = parse(p, "123")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 123
+            }
+
+            it("succeeds (float)") {
+                let r = parse(p, "123.45")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 123.45
+            }
+
+            it("succeeds (float + zero_start)") {
+                let r = parse(p, "0.25")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 0.25
+            }
+
+            it("succeeds (float + two zero_starts)") {
+                let r = parse(p, "00.25")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 0.25
+            }
+
+            it("succeeds (scientific)") {
+                let r = parse(p, "123.45e2")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 12345
+            }
+
+            it("succeeds ('+' prefix)") {
+                let r = parse(p, "+12.5e-1")._done
+                expect(r?.input) == ""
+                expect(r?.output) == 1.25
+            }
+
+            it("succeeds ('-' prefix)") {
+                let r = parse(p, "-12.5e-1")._done
+                expect(r?.input) == ""
+                expect(r?.output) == -1.25
+            }
+
+            it("succeeds (partial)") {
+                let r = parse(p, "-12.34.5e-1")._done
+                expect(r?.input) == ".5e-1"
+                expect(r?.output) == -12.34
+            }
+
+            it("fails") {
+                let r = parse(p, "=1")._fail
+                expect(r?.input) == "=1"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("endOfLine") {
+
+            let p = endOfLine
+
+            it("succeeds (\\n)") {
+                let r = parse(p, "\n")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+            it("succeeds (\\r\\n)") {
+                let r = parse(p, "\r\n")._done
+                expect(r?.input) == ""
+                expect(r?.output) == ()
+            }
+
+            it("fails") {
+                let r = parse(p, "abc")._fail
+                expect(r?.input) == "abc"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+    }
+}

--- a/excludedTests/TryParsecExperiment/Specs/UnicodeScalarViewSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/UnicodeScalarViewSpec.swift
@@ -1,4 +1,4 @@
-import TryParsec
+import TryParsecExperiment
 import Quick
 import Nimble
 

--- a/excludedTests/TryParsecExperiment/Specs/XMLSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/XMLSpec.swift
@@ -1,4 +1,4 @@
-@testable import TryParsec
+@testable import TryParsecExperiment
 import Quick
 import Nimble
 

--- a/excludedTests/TryParsecExperiment/Specs/XMLSpec.swift
+++ b/excludedTests/TryParsecExperiment/Specs/XMLSpec.swift
@@ -1,0 +1,372 @@
+@testable import TryParsec
+import Quick
+import Nimble
+
+class XMLSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("parseXML") {
+
+            it("succeeds") {
+
+                let xmlString = "<p class=\"welcome\"><a href=\"underground.html\" target=\"_blank\">Hello</a><?php echo ' Cruel'; ?> World<!-- 💀 --><![CDATA[💣->😇]]></p>"
+
+                let expected: [XML] = [
+                    .Element(
+                        "p",
+                        [XML.Attribute("class", "welcome")],
+                        [
+                            .Element(
+                                "a",
+                                [
+                                    XML.Attribute("href", "underground.html"),
+                                    XML.Attribute("target", "_blank")
+                                ],
+                                [.Text("Hello")]
+                            ),
+                            .ProcessingInstruction("php echo ' Cruel'; "),
+                            .Text(" World"),
+                            .Comment(" 💀 "),
+                            .Text("💣->😇")
+                        ]
+                    )
+                ]
+
+                let r = parseXML(xmlString)
+                expect(r.value) == expected
+
+            }
+
+            it("succeeds") {
+
+                let xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!--I love Swift-->\n<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n<?php /* I love Swift */ ?>\n\n<p class=\"intro\"><a href=\"somewhere\" target=\"_blank\"  >Hello</a> World<![CDATA[if (c<10)]]></p>"
+
+                let expected: [XML] = [
+                    .XMLDeclaration(" version=\"1.0\" encoding=\"UTF-8\""),
+                    .Comment("I love Swift"),
+                    .DOCTYPE(" HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\""),
+                    .ProcessingInstruction("php /* I love Swift */ "),
+                    .Element(
+                        "p",
+                        [XML.Attribute("class", "intro")],
+                        [
+                            .Element(
+                                "a",
+                                [XML.Attribute("href", "somewhere"), XML.Attribute("target", "_blank")],
+                                [.Text("Hello")]
+                            ),
+                            .Text("World"),
+                            .Text("if (c<10)")
+                        ]
+                    )
+                ]
+
+                let r = parseXML(xmlString)
+                expect(r.value) == expected
+
+            }
+
+        }
+
+        describe("XML (internal)") {
+
+            describe("DOCTYPE") {
+
+                let p = doctype
+
+                it("succeeds") {
+                    let str: USV = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .DOCTYPE(" HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\"")
+                }
+
+            }
+
+            describe("xmlDeclaration") {
+
+                let p = xmlDeclaration
+
+                it("succeeds") {
+                    let str: USV = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .XMLDeclaration(" version=\"1.0\" encoding=\"UTF-8\"")
+                }
+
+            }
+
+            describe("processingInstruction") {
+
+                let p = processingInstruction
+
+                it("succeeds") {
+                    let str: USV = "<?php /* I love Swift */ ?>"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .ProcessingInstruction("php /* I love Swift */ ")
+                }
+
+            }
+
+            describe("manyMisc") {
+
+                let p = manyMisc
+
+                it("succeeds") {
+                    let str: USV = "<!--I love Swift--><?php /* I love Swift */ ?><!--I love Swift-->"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == [
+                        .Comment("I love Swift"),
+                        .ProcessingInstruction("php /* I love Swift */ "),
+                        .Comment("I love Swift")
+                    ]
+                }
+
+            }
+
+            describe("attrValue") {
+
+                let p = attrValue
+
+                it("succeeds (double quote)") {
+                    let str: USV = "\"_blank\""
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "_blank"
+                }
+
+                it("succeeds (single quote)") {
+                    let str: USV = "'_blank'"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "_blank"
+                }
+
+                it("succeeds (with reference)") {
+                    let str: USV = "'&amp;'"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "&amp;"
+                }
+
+                it("fails (no quotes)") {
+                    let str: USV = "_blank"
+
+                    let r = parse(p, str)._fail
+                    expect(r?.input) == "_blank"
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+
+                it("fails (tag is not allowed)") {
+                    let str: USV = "\"<hr />\""
+
+                    let r = parse(p, str)._fail
+                    expect(r?.input) == "\"<hr />\""
+                    expect(r?.contexts) == []
+                    expect(r?.message) == "satisfy"
+                }
+            }
+
+            describe("attribute") {
+
+                let p = attribute
+
+                it("succeeds") {
+                    let str: USV = "target=\"_blank\""
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == XML.Attribute("target", "_blank")
+                }
+
+            }
+
+            describe("xmlElement") {
+
+                let p = xmlElement
+
+                it("succeeds (emptyElementTag)") {
+                    let str: USV = "<img src=\"somewhere\" />"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .EmptyElement("img", [ XML.Attribute("src", "somewhere") ])
+                }
+
+                it("succeeds (emptyElementTag + multiple attributes)") {
+                    let str: USV = "<img src=\"somewhere\" alt=\"...\"/>"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .EmptyElement("img", [
+                        XML.Attribute("src", "somewhere"),
+                        XML.Attribute("alt", "...")
+                    ])
+                }
+
+                it("succeeds (non-emptyElementTag)") {
+                    let str: USV = "<a href=\"somewhere\" target=\"_blank\">Hello</a>"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == .Element(
+                        "a",
+                        [
+                            XML.Attribute("href", "somewhere"),
+                            XML.Attribute("target", "_blank")
+                        ],
+                        [.Text("Hello")]
+                    )
+                }
+
+            }
+
+            describe("entityRef") {
+
+                let p = entityRef
+
+                it("succeeds (`&copy;`)") {
+                    let str: USV = "&copy;"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "&copy;"
+                }
+
+            }
+
+            describe("charRef") {
+
+                let p = charRef
+
+                it("succeeds (`&#xa9;`)") {
+                    let str: USV = "&#xa9;"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "&#xa9;"
+                }
+
+                it("succeeds (`&#169;`)") {
+                    let str: USV = "&#169;"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == "&#169;"
+                }
+
+            }
+
+            describe("prolog") {
+
+                let p = prolog
+
+                it("succeeds") {
+                    let str: USV = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!--I love Swift--><!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\"><!--I ♡ Swift--><?php /* I love Swift */ ?>"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == [
+                        .XMLDeclaration(" version=\"1.0\" encoding=\"UTF-8\""),
+                        .Comment("I love Swift"),
+                        .DOCTYPE(" HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\""),
+                        .Comment("I ♡ Swift"),
+                        .ProcessingInstruction("php /* I love Swift */ "),
+                    ]
+                }
+
+            }
+
+            describe("xmlContent") {
+
+                let p = xmlContent
+
+                it("succeeds (CharData only)") {
+                    let str: USV = "abc"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == [ .Text("abc") ]
+                }
+
+                it("succeeds (CharData + Comment)") {
+                    let str: USV = "abc<!-- comment -->"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == [
+                        .Text("abc"),
+                        .Comment(" comment ")
+                    ]
+                }
+
+                it("succeeds (CharData + PI + CharData)") {
+                    let str: USV = "Hello<?php echo \" Cruel\"; ?> World!"
+
+                    let r = parse(p, str)._done
+                    expect(r?.input) == ""
+                    expect(r?.output) == [
+                        .Text("Hello"),
+                        .ProcessingInstruction("php echo \" Cruel\"; "),
+                        .Text(" World!")
+                    ]
+                }
+
+            }
+
+            describe("xmlDocument") {
+
+                it("succeeds") {
+                    let str = self.dynamicType.loadString("test4", "xml")
+//                    let str = "<param-value>/content/admin/remove?cache=pages&amp;id=</param-value>"
+
+                    let p = xmlDocument
+                    let r = parse(p, str.unicodeScalars)._done
+                    expect(r?.input) == ""
+
+                    // Comment-Out: Constructing AST takes too long to compile...
+//                    expect(r?.output) == [ ... ]
+                }
+
+            }
+
+        }
+
+        describe("XML Files") {
+
+            beforeEach {
+                print("------------------------------")
+            }
+
+            it("parses XML files") {
+                let files = [ "test1", "test2", "test3", "test4", "test5" ]
+
+                for file in files {
+                    print("file = \(file)")
+                    print("")
+
+                    let xmlString = self.dynamicType.loadString(file, "xml")
+                    //print("xmlString = ", xmlString)
+                    print("")
+
+                    let xmlAST = parseXML(xmlString)
+                    expect(xmlAST.value).toNot(beNil())
+                    print("xmlAST = ", xmlAST)
+                    print("")
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
I leave notes about this branch.

When I found that 238fc98 improved performance, I thought that swift's optimizer couldn't enough jobs for some reason. 🤔 So, I did experiment for investigating what is avoiding the optimizer.

What I've found:
- Using closure directly instead of wrapping into struct
  - Does not affect swift's optimization
  - Using on custom operator's(e.g. `<|>`) right hand parameter with `@autoclosure` cause swift stop infer type of generic parameter
    <img width="761" alt="screenshot 2016-03-11 20 15 50" src="https://cloud.githubusercontent.com/assets/33430/13719507/10adf308-e83a-11e5-863e-38e7e015664e.png">

- Less generic parameter does not affect optimization. (Compiling duration might be affected, but I did not measure that.)
- Avoiding use `@autoclosure` does not affect optimization
- Overloading generic function by type specific function does improve performance some case as 238fc98 did, but worsen on most case.

I couldn't find what is avoiding the optimizer of swift. :disappointed: 

Now I delete the branch from this repo and leave that on my fork https://github.com/norio-nomura/TryParsec/tree/nn/experiment