### PR TITLE
Improve custom-operator precedences

### DIFF
--- a/Sources/TryParsec/Operators.swift
+++ b/Sources/TryParsec/Operators.swift
@@ -1,12 +1,29 @@
+// Keep custom-operator precedences as best we can.
+// - https://github.com/thoughtbot/Runes
+// - https://github.com/typelift/Operadics
+
+/// Haskell `infixl 1`.
 infix operator >>-  { associativity left precedence 100 }
 
-infix operator <|>  { associativity right precedence 130 }
+/// Haskell `infixl 3` (Haskell.Parsec `infixr 1 <|>`).
+/// - Note: typelift/Operadics use `precedence 120` for `infixr 2` and `precedence 130` for `infixl 4`.
+infix operator <|>  { associativity left precedence 125 }
 
-infix operator <*>  { associativity left precedence 140 }
+// Comment-Out: `associativity right` is not preferred (but interestingly, performance is slightly faster)
+//infix operator <|>  { associativity right precedence 100 }
+
+/// Haskell `infixl 4`.
+infix operator <*>  { associativity left precedence 130 }
+
+/// Haskell `infixl 4`.
 infix operator <*   { associativity left precedence 140 }
+
+/// Haskell `infixl 4`.
 infix operator *>   { associativity left precedence 140 }
 
-infix operator <^>  { associativity left precedence 140 }
-infix operator <&>  { associativity left precedence 140 }
+/// Haskell `infixl 4`.
+infix operator <^>  { associativity left precedence 130 }
+infix operator <&>  { associativity left precedence 130 }
 
-infix operator <?>  { associativity left precedence 0 }
+/// Haskell.Parsec/Attoparsec `infix 0`.
+infix operator <?>  { associativity none precedence 0 }


### PR DESCRIPTION
This is a pull-request for #9 to conform the same operator-precedences as following libraries:

- https://github.com/thoughtbot/Runes
- https://github.com/typelift/Operadics

As a side note, 

- `infix operator <|>  { associativity right }` was _slightly faster_ than `associativity left` (interesting), but I decided to conform to current Haskell's `infixl 3 <|>` with `precedence 125`.
  - `precedence 125` comes from middle value of `infix 2` (`precedence 120`) and `infix 4` (`precedence 130`) in [typelift/Operadics](https://github.com/typelift/Operadics).