### PR TITLE
Update for Swift 2.2 (Xcode 7.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - xcodebuild -workspace 'TryParsec.xcworkspace' -scheme 'TryParsec' -destination 'platform=iOS Simulator,name=iPhone 6s' test | xcpretty
   - xcodebuild -workspace 'TryParsec.xcworkspace' -scheme 'TryParsec' -destination 'platform=tvOS Simulator,name=Apple TV 1080p' test | xcpretty
   - xcodebuild -workspace 'TryParsec.xcworkspace' -scheme 'TryParsec' -destination 'platform=watchOS Simulator,name=Apple Watch - 38mm' build | xcpretty
-  - pod lib lint
+  - pod lib lint --allow-warnings
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 install:
   - brew update

--- a/Benchmark/Sources/TryParsecBenchmark/main.swift
+++ b/Benchmark/Sources/TryParsecBenchmark/main.swift
@@ -27,7 +27,7 @@ func startBenchmark<T>(f: String -> T, _ filename: String, _ fileExt: String)
     print(diffTime)
 }
 
-func loadString(resourceName: String, _ extensionName: String, filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__) -> String
+func loadString(resourceName: String, _ extensionName: String, filename: String = #file, functionName: String = #function, line: Int = #line) -> String
 {
 #if SWIFT_PACKAGE
     let resourceDir = "../../../TestAssets"

--- a/Sources/TryParsec/RangeReplaceableCollectionType+Helper.swift
+++ b/Sources/TryParsec/RangeReplaceableCollectionType+Helper.swift
@@ -6,15 +6,4 @@ extension RangeReplaceableCollectionType
         self.init()
         self.append(x)
     }
-
-#if !SWIFT_PACKAGE
-//#if swift(>=2.2)
-//#else
-    /// Missing initializer until Swift 2.1.
-    public init<S: SequenceType where S.Generator.Element == Self.Generator.Element>(_ xs: S)
-    {
-        self.init()
-        self.appendContentsOf(xs)
-    }
-#endif
 }

--- a/excludedTests/TryParsec/Helpers/XCTestCase+Helper.swift
+++ b/excludedTests/TryParsec/Helpers/XCTestCase+Helper.swift
@@ -14,7 +14,7 @@ extension XCTestCase
         super.tearDown()
     }
 
-    class func loadString(resourceName: String, _ extensionName: String, filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__) -> String
+    class func loadString(resourceName: String, _ extensionName: String, filename: String = #file, functionName: String = #function, line: Int = #line) -> String
     {
         let jsonString = NSBundle(forClass: self)
             .URLForResource("TestAssets/\(resourceName)", withExtension: extensionName)


### PR DESCRIPTION
Small migration to Swift 2.2 :tada: 
(`swift/2.2` branch has been created)

For Swift 3.0-dev, current latest `DEVELOPMENT-SNAPSHOT-2016-03-16-a` has `swift build` failure issue as reported in [[SR-975] SwiftPM seems broken in the latest snapshot - Swift](https://bugs.swift.org/browse/SR-975), so I didn't update `.swift-version` for now.