### PR TITLE
Add Permutation support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,6 +24,7 @@ opt_in_rules:
 included:
  - Sources
  - Tests
+ - excludedTests
  - Benchmark
 
 excluded:

--- a/Sources/TryParsec/Operators+Permutation.swift
+++ b/Sources/TryParsec/Operators+Permutation.swift
@@ -1,0 +1,5 @@
+infix operator <^^>  { associativity left precedence 110 }
+infix operator <^?>  { associativity left precedence 110 }
+
+infix operator <||>  { associativity left precedence 100 }
+infix operator <|?>  { associativity left precedence 100 }

--- a/Sources/TryParsec/Operators.swift
+++ b/Sources/TryParsec/Operators.swift
@@ -9,4 +9,7 @@ infix operator *>   { associativity left precedence 140 }
 infix operator <^>  { associativity left precedence 140 }
 infix operator <&>  { associativity left precedence 140 }
 
+infix operator >>>  { associativity right precedence 100 }
+infix operator <<<  { associativity right precedence 100 }
+
 infix operator <?>  { associativity left precedence 0 }

--- a/Sources/TryParsec/Parser+Combinator.swift
+++ b/Sources/TryParsec/Parser+Combinator.swift
@@ -199,3 +199,9 @@ public func lookAhead<In, Out>(p: Parser<In, Out>) -> Parser<In, Out>
         }
     }
 }
+
+/// Folds `parsers` using Alternative's `<|>`.
+public func choice<In, Out, S: SequenceType where S.Generator.Element == Parser<In, Out>>(parsers: S) -> Parser<In, Out>
+{
+    return parsers.reduce(empty(), combine: { $0 <|> $1 })
+}

--- a/Sources/TryParsec/Permutation.swift
+++ b/Sources/TryParsec/Permutation.swift
@@ -1,0 +1,112 @@
+//
+//  Permutation.swift
+//  TryParsec
+//
+//  Created by Yasuhiro Inami on 2016-07-13.
+//  Copyright © 2016 Yasuhiro Inami. All rights reserved.
+//
+
+public struct Permutation<In, Out>
+{
+    private let output: Out?
+    private let branches: [Branch<In, Out>]
+
+    private func map<Out2>(f: Out -> Out2) -> Permutation<In, Out2>
+    {
+        return Permutation<In, Out2>(output: self.output.map(f), branches: self.branches.map { $0.map(f) })
+    }
+}
+
+public struct Branch<In, Out>
+{
+    private let perm: Permutation<In, Any -> Out>
+    private let parser: Parser<In, Any>
+
+    private func map<Out2>(f: Out -> Out2) -> Branch<In, Out2>
+    {
+        return Branch<In, Out2>(perm: self.perm.map { f <<< $0 }, parser: self.parser)
+    }
+}
+
+public func permute<In, Out>(perm: Permutation<In, Out>) -> Parser<In, Out>
+{
+    let empty: [Parser<In, Out>] = perm.output.map { [pure($0)] } ?? []
+
+    let nonempty = perm.branches.map { b in
+        b.parser >>- { x in
+            permute(b.perm) >>- { f in
+                pure(f(x))
+            }
+        }
+    }
+
+    return choice(nonempty + empty)
+}
+
+/// Creates new `Permutation` with `f`, and adds `parser`.
+public func <^^> <In, Out, Out2>(f: Out -> Out2, parser: Parser<In, Out>) -> Permutation<In, Out2>
+{
+    return _new(f) <||> parser
+}
+
+/// Adds `parser` to `perm`.
+public func <||> <In, Out, Out2>(perm: Permutation<In, Out -> Out2>, parser: Parser<In, Out>) -> Permutation<In, Out2>
+{
+    return _add(perm, parser)
+}
+
+/// Creates new `Permutation` with `f`,
+/// and _optionally_ adds parser `tuple.1` with fallback value `tuple.0`.
+public func <^?> <In, Out, Out2>(f: Out -> Out2, tuple: (Out, Parser<In, Out>)) -> Permutation<In, Out2>
+{
+    return _new(f) <|?> tuple
+}
+
+/// _Optionally_ adds parser `tuple.1` with fallback value `tuple.0`.
+public func <|?> <In, Out, Out2>(perm: Permutation<In, Out -> Out2>, tuple: (Out, Parser<In, Out>)) -> Permutation<In, Out2>
+{
+    return _addOpt(perm, tuple.0, tuple.1)
+}
+
+// MARK: Private
+
+/// Creates new `Permutation` with `output` only (no branches).
+private func _new<In, Out>(output: Out) -> Permutation<In, Out>
+{
+    return Permutation(output: output, branches: [])
+}
+
+/// Adds `parser` to `perm`.
+private func _add<In, Out, Out2>(perm: Permutation<In, Out -> Out2>, _ parser: Parser<In, Out>) -> Permutation<In, Out2>
+{
+    let b = Branch<In, Out2>(perm: perm.map(_toAny), parser: _toAny(parser))
+    let bs = perm.branches.map {
+        Branch<In, Out2>(perm: _add($0.perm.map(flip), parser), parser: $0.parser)
+    }
+
+    return Permutation<In, Out2>(output: nil, branches: cons(b)(bs))
+}
+
+/// Adds _optional_ `parser` to `perm`.
+/// If `p` can not be applied, the fallback value `x` will be used instead.
+private func _addOpt<In, Out, Out2>(perm: Permutation<In, Out -> Out2>, _ x: Out, _ parser: Parser<In, Out>) -> Permutation<In, Out2>
+{
+    let b = Branch<In, Out2>(perm: perm.map(_toAny), parser: _toAny(parser))    // workaround for existential type
+    let bs = perm.branches.map {
+        Branch<In, Out2>(perm: _addOpt($0.perm.map(flip), x, parser), parser: $0.parser)
+    }
+
+    return Permutation<In, Out2>(output: perm.output?(x), branches: cons(b)(bs))
+}
+
+/// Converts `parser`'s `Out` type to `Any`.
+private func _toAny<In, Out>(parser: Parser<In, Out>) -> Parser<In, Any>
+{
+    return { $0 } <^> parser
+}
+
+/// Converts `A -> B` to `Any -> B`.
+private func _toAny<A, B>(f: A -> B) -> Any -> B
+{
+    return { f($0 as! A) }  // swiftlint:disable:this force_cast
+}

--- a/Sources/TryParsec/Permutation.swift
+++ b/Sources/TryParsec/Permutation.swift
@@ -17,7 +17,7 @@ public struct Permutation<In, Out>
     }
 }
 
-public struct Branch<In, Out>
+private struct Branch<In, Out>
 {
     private let perm: Permutation<In, Any -> Out>
     private let parser: Parser<In, Any>

--- a/Sources/TryParsec/Prelude.swift
+++ b/Sources/TryParsec/Prelude.swift
@@ -55,6 +55,21 @@ internal func splitAt<C: CollectionType>(count: C.Index.Distance) -> C -> (C.Sub
     }
 }
 
+internal func flip<A, B, C>(f: A -> B -> C) -> B -> A -> C
+{
+    return { b in { a in f(a)(b) } }
+}
+
+internal func <<< <A, B, C>(f: B -> C, g: A -> B) -> A -> C
+{
+    return { f(g($0)) }
+}
+
+internal func >>> <A, B, C>(f: A -> B, g: B -> C) -> A -> C
+{
+    return { g(f($0)) }
+}
+
 /// Fixed-point combinator.
 internal func fix<T, U>(f: (T -> U) -> T -> U) -> T -> U
 {

--- a/TryParsec.xcodeproj/project.pbxproj
+++ b/TryParsec.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1F110F061B8C165B00798BA0 /* Parser+Combinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F110F051B8C165B00798BA0 /* Parser+Combinator.swift */; };
 		1F110F0A1B8C18E100798BA0 /* Parser+Arithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F110F091B8C18E100798BA0 /* Parser+Arithmetic.swift */; };
 		1F258C941C2F09FA00D9C0E2 /* Result+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F258C931C2F09FA00D9C0E2 /* Result+Helper.swift */; };
+		1F2A1A7D1D327A340012B5C3 /* PermutationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2A1A7B1D32797C0012B5C3 /* PermutationSpec.swift */; };
 		1F39576E1BD54767000BD9A0 /* Operators+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39576D1BD54767000BD9A0 /* Operators+JSON.swift */; };
 		1F4383351BBAFEE700FF330A /* Parser+UnicodeScalarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4383341BBAFEE700FF330A /* Parser+UnicodeScalarView.swift */; };
 		1F57FCA51C45E24200484EBD /* Dictionary+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F57FCA41C45E24200484EBD /* Dictionary+Helper.swift */; };
@@ -55,6 +56,8 @@
 		1FC183011C6AC19B00FB1EC9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC182601C6AC19A00FB1EC9 /* main.swift */; };
 		1FC183B11C6AC23A00FB1EC9 /* TryParsec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE8E41F1B896E9100E1F2D0 /* TryParsec.framework */; };
 		1FC183B31C6AC24100FB1EC9 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FC183B21C6AC24100FB1EC9 /* Result.framework */; };
+		1FCCF9101D309CC800B6B86E /* Permutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCCF90F1D309CC800B6B86E /* Permutation.swift */; };
+		1FCCF9121D309D0400B6B86E /* Operators+Permutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCCF9111D309D0400B6B86E /* Operators+Permutation.swift */; };
 		1FD6385A1C378EAB00941439 /* RangeReplaceableCollectionType+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD638591C378EAB00941439 /* RangeReplaceableCollectionType+Helper.swift */; };
 		1FD638601C37A34500941439 /* UnicodeScalarView+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD6385F1C37A34500941439 /* UnicodeScalarView+Helper.swift */; };
 		1FE03AF01BB7BEF300D16C55 /* Parser+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE03AEF1BB7BEF300D16C55 /* Parser+XML.swift */; };
@@ -101,6 +104,7 @@
 		1F110F051B8C165B00798BA0 /* Parser+Combinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+Combinator.swift"; sourceTree = "<group>"; };
 		1F110F091B8C18E100798BA0 /* Parser+Arithmetic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+Arithmetic.swift"; sourceTree = "<group>"; };
 		1F258C931C2F09FA00D9C0E2 /* Result+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Helper.swift"; sourceTree = "<group>"; };
+		1F2A1A7B1D32797C0012B5C3 /* PermutationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermutationSpec.swift; sourceTree = "<group>"; };
 		1F39576D1BD54767000BD9A0 /* Operators+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operators+JSON.swift"; sourceTree = "<group>"; };
 		1F4383341BBAFEE700FF330A /* Parser+UnicodeScalarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parser+UnicodeScalarView.swift"; sourceTree = "<group>"; };
 		1F57FCA41C45E24200484EBD /* Dictionary+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Helper.swift"; sourceTree = "<group>"; };
@@ -132,6 +136,8 @@
 		1FC182431C6AC14200FB1EC9 /* TryParsecBenchmark.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TryParsecBenchmark.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FC182601C6AC19A00FB1EC9 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = TryParsecBenchmark/main.swift; sourceTree = "<group>"; };
 		1FC183B21C6AC24100FB1EC9 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "../../Library/Developer/Xcode/DerivedData/TryParsec-bergsxxpazqchkerucnpexyejxub/Build/Products/Release/Result.framework"; sourceTree = "<group>"; };
+		1FCCF90F1D309CC800B6B86E /* Permutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permutation.swift; sourceTree = "<group>"; };
+		1FCCF9111D309D0400B6B86E /* Operators+Permutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operators+Permutation.swift"; sourceTree = "<group>"; };
 		1FD638591C378EAB00941439 /* RangeReplaceableCollectionType+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollectionType+Helper.swift"; sourceTree = "<group>"; };
 		1FD6385F1C37A34500941439 /* UnicodeScalarView+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnicodeScalarView+Helper.swift"; sourceTree = "<group>"; };
 		1FDF639A1C417DA3004AF11D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -244,6 +250,7 @@
 				1FA466911C67F45A0089C8D9 /* ParserSpec.swift */,
 				1FA4668D1C67F45A0089C8D9 /* CombinatorSpec.swift */,
 				1FA466921C67F45A0089C8D9 /* UnicodeScalarViewSpec.swift */,
+				1F2A1A7B1D32797C0012B5C3 /* PermutationSpec.swift */,
 				1FA4668C1C67F45A0089C8D9 /* ArithmeticSpec.swift */,
 				1FA4668E1C67F45A0089C8D9 /* CSVSpec.swift */,
 				1FA466931C67F45A0089C8D9 /* XMLSpec.swift */,
@@ -303,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				1FE60F5D1B8CA7FF00189CE0 /* Operators.swift */,
+				1FCCF9111D309D0400B6B86E /* Operators+Permutation.swift */,
 				1F258C931C2F09FA00D9C0E2 /* Result+Helper.swift */,
 				1FD6385F1C37A34500941439 /* UnicodeScalarView+Helper.swift */,
 				1FD638591C378EAB00941439 /* RangeReplaceableCollectionType+Helper.swift */,
@@ -366,6 +374,7 @@
 				1F4383341BBAFEE700FF330A /* Parser+UnicodeScalarView.swift */,
 				1F92984B1BC3534A00B68621 /* Reply.swift */,
 				1F9824B21C41372C00D68090 /* ParseError.swift */,
+				1FCCF90F1D309CC800B6B86E /* Permutation.swift */,
 				1FD19BB71B8E41730066895A /* Basis */,
 				1FAAF1611BD2FF0300B26694 /* Arithmetic */,
 				1FAAF15F1BD2FEFA00B26694 /* CSV */,
@@ -634,12 +643,14 @@
 				1FE60F5E1B8CA7FF00189CE0 /* Operators.swift in Sources */,
 				1F92984C1BC3534A00B68621 /* Reply.swift in Sources */,
 				1FAAF1631BD2FF8900B26694 /* FromJSON.swift in Sources */,
+				1FCCF9121D309D0400B6B86E /* Operators+Permutation.swift in Sources */,
 				1F8A4FC21BBB6B1D00BE5CDD /* Parser+JSON.swift in Sources */,
 				1FE21A4D1C48800B00494E64 /* XML.swift in Sources */,
 				1F258C941C2F09FA00D9C0E2 /* Result+Helper.swift in Sources */,
 				1FF2461C1BDCBF0500570D8D /* DoubleType.swift in Sources */,
 				1FD6385A1C378EAB00941439 /* RangeReplaceableCollectionType+Helper.swift in Sources */,
 				1FE03AF01BB7BEF300D16C55 /* Parser+XML.swift in Sources */,
+				1FCCF9101D309CC800B6B86E /* Permutation.swift in Sources */,
 				1F9824B31C41372C00D68090 /* ParseError.swift in Sources */,
 				1F4383351BBAFEE700FF330A /* Parser+UnicodeScalarView.swift in Sources */,
 				1FE21A4B1C487F4300494E64 /* JSON.swift in Sources */,
@@ -658,6 +669,7 @@
 				1F7B76961C68F40F008DC0A1 /* ArithmeticSpec.swift in Sources */,
 				1F7B769D1C68F40F008DC0A1 /* XMLSpec.swift in Sources */,
 				1F7B76991C68F40F008DC0A1 /* HelperSpec.swift in Sources */,
+				1F2A1A7D1D327A340012B5C3 /* PermutationSpec.swift in Sources */,
 				1F7B76981C68F40F008DC0A1 /* CSVSpec.swift in Sources */,
 				1F7B76971C68F40F008DC0A1 /* CombinatorSpec.swift in Sources */,
 				1FA466881C67F3FE0089C8D9 /* TestHelper.swift in Sources */,

--- a/excludedTests/TryParsec/Helpers/TestHelper.swift
+++ b/excludedTests/TryParsec/Helpers/TestHelper.swift
@@ -24,3 +24,37 @@ extension Reply
 }
 
 typealias USV = String.UnicodeScalarView
+
+// MARK: Helpers
+
+// From https://www.objc.io/blog/2014/10/06/functional-snippet-1-decomposing-arrays/
+
+extension Array
+{
+    var decompose: (head: Generator.Element, tail: [Generator.Element])? {
+        return (count > 0) ? (self[0], Array(self[1..<count])) : nil
+    }
+}
+
+/// e.g. `between(0, [1, 2, 3]) = [[0, 1, 2, 3], [1, 0, 2, 3], [1, 2, 0, 3], [1, 2, 3, 0]]`.
+func between<T>(x: T, _ ys: [T]) -> [[T]]
+{
+    if let (head, tail) = ys.decompose {
+        return [[x] + ys] + between(x, tail).map { (val: [T]) -> [T] in [head] + val } // explict type-annotation is needed for faster type-inference
+    }
+    else {
+        return [[x]]
+    }
+}
+
+func permutations<T>(xs: [T]) -> [[T]]
+{
+    if let (head, tail) = xs.decompose {
+        return permutations(tail).flatMap { permTail in
+            between(head, permTail)
+        }
+    }
+    else {
+        return [[]]
+    }
+}

--- a/excludedTests/TryParsec/Specs/PermutationSpec.swift
+++ b/excludedTests/TryParsec/Specs/PermutationSpec.swift
@@ -1,0 +1,170 @@
+import TryParsec
+import Quick
+import Nimble
+
+class PermutationSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("Permutation (n=1)") {
+
+            let perm: Permutation<USV, USV> =
+                { $0 } <^^> string("abc")
+
+            let p: Parser<USV, USV> = permute(perm)
+
+            it("succeeds") {
+                let r = parse(p, "abc123")._done
+                expect(r?.input) == "123"
+                expect(r?.output) == "abc"
+            }
+
+            it("fails (wrong input)") {
+                let r = parse(p, "123")._fail
+                expect(r?.input) == "123"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("Permutation (n=2)") {
+
+            let perm: Permutation<USV, USV> =
+                { a in { b in a + "," + b } }
+                    <^^> string("abc")
+                    <||> string("123")
+
+            let p: Parser<USV, USV> = permute(perm)
+
+            it("succeeds") {
+                let r = parse(p, "abc123")._done
+                expect(r?.input) == ""
+                expect(r?.output) == "abc,123"
+            }
+
+            it("succeeds (reordered)") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == ""
+                expect(r?.output) == "abc,123"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("Permutation (n=2, required + optional)") {
+
+            let perm: Permutation<USV, USV> =
+                { a in { b in a + "," + b } }
+                    <^^> string("abc")          // `<^^>` or `<||>` as required
+                    <|?> ("_", string("123"))   // `<^?>` or `<|?>` as optional
+
+            let p: Parser<USV, USV> = permute(perm)
+
+            it("succeeds") {
+                let r = parse(p, "abc123")._done
+                expect(r?.input) == ""
+                expect(r?.output) == "abc,123"
+            }
+
+            it("succeeds (reordered)") {
+                let r = parse(p, "123abc")._done
+                expect(r?.input) == ""
+                expect(r?.output) == "abc,123"
+            }
+
+            it("succeeds ('123' is optional)") {
+                let r = parse(p, "abc???")._done
+                expect(r?.input) == "???"
+                expect(r?.output) == "abc,_"
+            }
+
+            it("fails ('abc' is required)") {
+                let r = parse(p, "123")._fail
+                expect(r?.input) == "123"
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+            it("fails (no input)") {
+                let r = parse(p, "")._fail
+                expect(r?.input) == ""
+                expect(r?.contexts) == []
+                expect(r?.message) == "satisfy"
+            }
+
+        }
+
+        describe("Permutation (n=3, URL-query example)") {
+
+            /// Extracts "value" from "\(key)=value&...".
+            func valueParser(key: USV) -> Parser<USV, USV>
+            {
+                return string(key + "=") *> many1(noneOf("&#")) <* zeroOrOne(char("&"))
+            }
+
+            let perm: Permutation<USV, (USV, USV, USV)> =
+                { a in { b in { c in (a, b, c) } } }
+                    <^?> ("_", valueParser("key1"))
+                    <|?> ("_", valueParser("key2"))
+                    <|?> ("_", valueParser("key3"))
+
+            let p: Parser<USV, (USV, USV, USV)> = permute(perm)
+
+            it("succeeds") {
+                let r = parse(p, "key1=a&key2=b&key3=c#hello")._done
+                expect(r?.input) == "#hello"
+                expect(r?.output.0) == "a"
+                expect(r?.output.1) == "b"
+                expect(r?.output.2) == "c"
+            }
+
+            it("succeeds (reordered)") {
+                let keyValues: [String] = ["key1=a", "key2=b", "key3=c"]
+                let patterns = permutations(keyValues)
+
+                for pattern in patterns {
+                    /// e.g. "key2=b&key1=a&key3=c"
+                    let query: String = pattern.joinWithSeparator("&")
+
+                    let r = parse(p, query.unicodeScalars)._done
+                    expect(r?.input) == ""
+                    expect(r?.output.0) == "a"
+                    expect(r?.output.1) == "b"
+                    expect(r?.output.2) == "c"
+                }
+            }
+
+            it("succeeds (keyValues are optional)") {
+                let r = parse(p, "key3=c&key2=b#hello")._done
+                expect(r?.input) == "#hello"
+                expect(r?.output.0) == "_"
+                expect(r?.output.1) == "b"
+                expect(r?.output.2) == "c"
+            }
+
+            it("succeeds (no input)") {
+                let r = parse(p, "")._done
+                expect(r?.input) == ""
+                expect(r?.output.0) == "_"
+                expect(r?.output.1) == "_"
+                expect(r?.output.2) == "_"
+            }
+
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request adds Permutation support to parse texts using multiple parsers in any order, such as parsing XML attributes or URL queries, which can be either required or optional.

### Example

```swift
typealias USV = String.UnicodeScalarView

func valueParser(key: USV) -> Parser<USV, USV>
{
    return string(key + "=") *> many1(noneOf("&#")) <* zeroOrOne(char("&"))
}

let perm: Permutation<USV, (USV, USV, USV)> =
    { a in { b in { c in (a, b, c) } } }
        <^^> valueParser("key1")  // required
        <||> valueParser("key2")  // required
        <|?> ("_", valueParser("key3"))  // optional with fallback value

let p: Parser<USV, (USV, USV, USV)> = permute(perm)

it("succeeds") {
    let r = parse(p, "key2=b&key1=a#hello")._done
    expect(r?.input) == "#hello"  // remaining input
    expect(r?.output.0) == "a"    // from "key1"
    expect(r?.output.1) == "b"    // from "key2"
    expect(r?.output.2) == "_"    // from "key3" but missing
}
```

### Reference

- [Parsing Permutation Phrases (PDF)](http://www.cs.ox.ac.uk/jeremy.gibbons/wg21/meeting56/loeh-paper.pdf)
- [Text.Parsec.Perm](https://hackage.haskell.org/package/parsec-3.1.11/docs/Text-Parsec-Perm.html)